### PR TITLE
Update harbor-values.yaml to not require SC

### DIFF
--- a/prod-values/harbor-values.yaml
+++ b/prod-values/harbor-values.yaml
@@ -1,6 +1,88 @@
 expose:
     type: loadBalancer
     tls:
+        # For now tls is disabled
         enabled: false
 loadBalancer:
-    IP: 
+    # You must assign a floating IP 
+    IP: ""
+database:
+    type: external
+    external:
+        host: ""
+        port: "5432"
+        username: ""
+        password: ""
+        coreDatabase: "registry"
+        # if using existing secret, the key must be "password"
+        #existingSecret: ""
+        # "disable" - No SSL
+        # "require" - Always SSL (skip verification)
+        # "verify-ca" - Always SSL (verify that the certificate presented by the
+        # server was signed by a trusted CA)
+        # "verify-full" - Always SSL (verify that the certification presented by the
+        # server was signed by a trusted CA and the server host name matches the one
+        # in the certificate)
+        sslmode: "disable"
+    # The maximum number of connections in the idle connection pool per pod (core+exporter).
+    # If it <=0, no idle connections are retained.
+    maxIdleConns: 100
+    # The maximum number of open connections to the database per pod (core+exporter).
+    # If it <= 0, then there is no limit on the number of open connections.
+    # Note: the default number of connections is 1024 for postgre of harbor.
+    maxOpenConns: 900
+    ## Additional deployment annotations
+    podAnnotations: {}
+    ## Additional deployment labels
+    podLabels: {}
+jobservice:
+    jobLoggers: 
+        - database
+
+# The persistence is enabled by default and a default StorageClass
+# is needed in the k8s cluster to provision volumes dynamically.
+# Specify another StorageClass in the "storageClass" or set "existingClaim"
+# if you already have existing persistent volumes to use
+#
+# For storing images and charts, you can also use "azure", "gcs", "s3",
+# "swift" or "oss". Set it in the "imageChartStorage" section
+persistence:
+    enabled: false
+    resourcePolicy: ""
+    imageChartStorage:
+    # Specify whether to disable `redirect` for images and chart storage, for
+    # backends which not supported it (such as using minio for `s3` storage type), please disable
+    # it. To disable redirects, simply set `disableredirect` to `true` instead.
+    # Refer to
+    # https://github.com/distribution/distribution/blob/main/docs/configuration.md#redirect
+    # for the detail.
+    disableredirect: false
+    # Specify the "caBundleSecretName" if the storage service uses a self-signed certificate.
+    # The secret must contain keys named "ca.crt" which will be injected into the trust store
+    # of registry's containers.
+    # caBundleSecretName:
+
+    # Specify the type of storage: "filesystem", "azure", "gcs", "s3", "swift",
+    # "oss" and fill the information needed in the corresponding section. The type
+    # must be "filesystem" if you want to use persistent volumes for registry
+    type: filesystem
+    swift:
+      authurl: https://storage.myprovider.com/v3/auth
+      username: username
+      password: password
+      container: containername
+      #region: fr
+      #tenant: tenantname
+      #tenantid: tenantid
+      #domain: domainname
+      #domainid: domainid
+      #trustid: trustid
+      #insecureskipverify: false
+      #chunksize: 5M
+      #prefix:
+      #secretkey: secretkey
+      #accesskey: accesskey
+      #authversion: 3
+      #endpointtype: public
+      #tempurlcontainerkey: false
+      #tempurlmethods:

--- a/prod-values/harbor-values.yaml
+++ b/prod-values/harbor-values.yaml
@@ -47,7 +47,7 @@ jobservice:
 # For storing images and charts, you can also use "azure", "gcs", "s3",
 # "swift" or "oss". Set it in the "imageChartStorage" section
 persistence:
-    enabled: false
+    enabled: true
     resourcePolicy: ""
     imageChartStorage:
     # Specify whether to disable `redirect` for images and chart storage, for


### PR DESCRIPTION
Related issue: https://stfc.atlassian.net/browse/CLDSCRM-592?atlOrigin=eyJpIjoiMWUzMDI3NTVkOWFkNGQ2ZDliYzc4NDVhYzAxYTMzOTYiLCJwIjoiaiJ9

Changes:
- [X] Disabling persistence
- [X] Configuration for external postgres DB for storage and logging.
- [X] Configuration now also has entry for setting swift as external database for images and charts (but is currently unused).