### PR TITLE
Removing swift config and add s3 config

### DIFF
--- a/prod-values/harbor-values.yaml
+++ b/prod-values/harbor-values.yaml
@@ -66,23 +66,23 @@ persistence:
     # "oss" and fill the information needed in the corresponding section. The type
     # must be "filesystem" if you want to use persistent volumes for registry
     type: filesystem
-    swift:
-      authurl: https://storage.myprovider.com/v3/auth
-      username: username
-      password: password
-      container: containername
-      #region: fr
-      #tenant: tenantname
-      #tenantid: tenantid
-      #domain: domainname
-      #domainid: domainid
-      #trustid: trustid
-      #insecureskipverify: false
-      #chunksize: 5M
-      #prefix:
-      #secretkey: secretkey
-      #accesskey: accesskey
-      #authversion: 3
-      #endpointtype: public
-      #tempurlcontainerkey: false
-      #tempurlmethods:
+    s3:
+        # Set an existing secret for S3 accesskey and secretkey
+        # keys in the secret should be REGISTRY_STORAGE_S3_ACCESSKEY and REGISTRY_STORAGE_S3_SECRETKEY for registry
+        #existingSecret: ""
+        region: us-west-1
+        bucket: bucketname
+        #accesskey: awsaccesskey
+        #secretkey: awssecretkey
+        #regionendpoint: http://myobjects.local
+        #encrypt: false
+        #keyid: mykeyid
+        #secure: true
+        #skipverify: false
+        #v4auth: true
+        #chunksize: "5242880"
+        #rootdirectory: /s3/object/name/prefix
+        #storageclass: STANDARD
+        #multipartcopychunksize: "33554432"
+        #multipartcopymaxconcurrency: 100
+        #multipartcopythresholdsize: "33554432"


### PR DESCRIPTION
Removing swift config and replacing it with s3, as Harbor is planning to move away from swift after version 3.0.

See: https://github.com/goharbor/harbor/issues/19317

