### PR TITLE
point test cluster to use dev chart

### DIFF
--- a/clusters/staging-management-cluster/infra-values.yaml
+++ b/clusters/staging-management-cluster/infra-values.yaml
@@ -37,6 +37,7 @@ infra:
 
   - name: anish-monitoring-test
     disableAutomated: false
+    targetRevision: anish-test-cluster
     chartName: capi
     namespace: clusters
     additionalValueFiles:


### PR DESCRIPTION
this cluster needs to be built using the development chart which is configured on a development branch
