### PR TITLE
ENH: Enable Monitoring on CAPI

### DIFF
--- a/charts/argocd-infra/values.yaml
+++ b/charts/argocd-infra/values.yaml
@@ -22,3 +22,4 @@ valueFiles:
   - charts/infra/capi/values.yaml
   - charts/infra/capi/certs.yaml
   - charts/infra/capi/networking.yaml
+  - charts/infra/capi/addons/monitoring.yaml

--- a/charts/infra/capi/addons/monitoring.yaml
+++ b/charts/infra/capi/addons/monitoring.yaml
@@ -7,6 +7,12 @@ openstack-cluster:
       kubePrometheusStack:
         release:
           values:
+
+            defaultRules:
+              additionalRuleLabels:
+                cluster: anish-monitoring-cluster
+                env: dev
+            
             alertmanager:
               enabled: true
               service:
@@ -34,7 +40,6 @@ openstack-cluster:
                   smtp_require_tls: false
 
                 route:
-                  group_by: ['cluster', 'service']
                   group_wait: 30m
                   group_interval: 30m
                   repeat_interval: 2d
@@ -75,11 +80,11 @@ openstack-cluster:
                     send_resolved: true
                     headers:
                       subject: |
-                        {% raw %}
+                        {%- raw %}
                         "({{ .CommonLabels.env }} : {{ .CommonLabels.cluster }}) {{ .Status | toUpper }} {{ .CommonLabels.alertname }}"
-                        {% endraw %}
+                        {%- endraw %}
                     html: |-
-                      {% raw %}
+                      {%- raw %}
                       <h3>You have the following alerts:</h3>
                       {{ range .Alerts }}
                       <p><b>{{.Labels.alertname}}</b>
@@ -91,10 +96,9 @@ openstack-cluster:
                         {{ end }}</ul>
                         {{ .GeneratorURL }}</p>
                       {{ end }}
-                      {% endraw %}
-
+                      {%- endraw %}
                     text: |-
-                      {% raw %}
+                      {%- raw %}
                       You have the following alerts:
                       {{ range .Alerts }}
                       * {{.Labels.alertname}}
@@ -106,14 +110,12 @@ openstack-cluster:
                         {{ end }}
                         {{ .GeneratorURL }}
                       {{ end }}
-                      {% endraw %}
+                      {%- endraw %}
 
                 templates:
                   - '/etc/alertmanager/config/*.tmpl'
 
               alertmanagerSpec:
-                alertmanagerConfigMatcherStrategy: {}
-                alertmanagerConfigSelector: {}
                 # turn off persistent storage so cinder volume doesn't get created
                 # TODO: remove this when cinder creation issue resolved          
                 storage: 

--- a/charts/infra/capi/addons/monitoring.yaml
+++ b/charts/infra/capi/addons/monitoring.yaml
@@ -14,7 +14,7 @@ openstack-cluster:
                 env: dev
             
             alertmanager:
-              enabled: true
+              enabled: false
               service:
                 type: ClusterIP
               

--- a/charts/infra/capi/addons/monitoring.yaml
+++ b/charts/infra/capi/addons/monitoring.yaml
@@ -1,25 +1,5 @@
 openstack-cluster:
-  controlPlane:
-    machineCount: 3
-
-  nodeGroups:
-    - name: default-md-0
-      machineCount: 2
-
-  nodeGroupDefaults:
-    machineFlavor: l3.tiny
-
-  cloudCredentialsSecretName: anish-cloud-credentials
-
   addons:
-    ingress:
-      enabled: true
-      nginx:
-        release:
-          values:
-            controller:
-              service:
-                loadBalancerIP: "130.246.211.60"
     monitoring:
       enabled: true
       lokiStack:
@@ -36,13 +16,13 @@ openstack-cluster:
                 ingressClassName: nginx
                 enabled: true
                 hosts: 
-                  - alertmanager-test.staging.nubes.stfc.ac.uk
+                  -  alertmanager.example.com
                 paths:
                   - "/"
                 tls: 
                   - hosts: 
-                    - alertmanager-test.staging.nubes.stfc.ac.uk
-                    secretName: tls-keypair              
+                    - "alertmanager.example.com"
+                    secretName: tls-keypair
                 ingressPerReplica:
                   enabled: false
 
@@ -152,10 +132,10 @@ openstack-cluster:
                 enabled: true
                 path: /
                 hosts: 
-                  -  grafana-test.staging.nubes.stfc.ac.uk
+                  -  grafana.example.com
                 tls:
                   - hosts: 
-                    - "grafana-test.staging.nubes.stfc.ac.uk"
+                    - "grafana.example.com"
                     secretName: tls-keypair
 
 
@@ -174,10 +154,10 @@ openstack-cluster:
                 paths:
                   - /
                 hosts: 
-                  -  prometheus-test.staging.nubes.stfc.ac.uk
+                  -  prometheus.example.com
                 tls: 
                   - hosts: 
-                    - "prometheus-test.staging.nubes.stfc.ac.uk"
+                    - "prometheus.example.com"
                     secretName: tls-keypair
               
               prometheusSpec:

--- a/charts/infra/capi/values.yaml
+++ b/charts/infra/capi/values.yaml
@@ -3,9 +3,6 @@ openstack-cluster:
 
   addons:
 
-    monitoring:
-      enabled: false
-
     openstack:
       csiCinder:
         defaultStorageClass:

--- a/charts/infra/capi/values.yaml
+++ b/charts/infra/capi/values.yaml
@@ -2,8 +2,8 @@ openstack-cluster:
   # Default values applied to all clusters unless override supersedes it
 
   addons:
+
     monitoring:
-      # disabled for now whilst working out how best to configure it
       enabled: false
 
     openstack:

--- a/clusters/anish-monitoring-test/app-values.yaml
+++ b/clusters/anish-monitoring-test/app-values.yaml
@@ -1,0 +1,7 @@
+global:
+  clusterName: staging-management-cluster
+  spec:
+    source:
+      targetRevision: anish-test-cluster
+      repoURL: https://github.com/stfc/cloud-deployed-apps.git
+      namespace: argocd

--- a/clusters/anish-monitoring-test/argocd-values.yaml
+++ b/clusters/anish-monitoring-test/argocd-values.yaml
@@ -1,0 +1,3 @@
+argo-cd:
+  global:
+    domain: argocd.test.nubes.stfc.ac.uk

--- a/clusters/anish-monitoring-test/overrides/infra/deployment.yaml
+++ b/clusters/anish-monitoring-test/overrides/infra/deployment.yaml
@@ -55,7 +55,7 @@ openstack-cluster:
                 global:
                   resolve_timeout: 5m
                   smtp_smarthost: 
-                  smtp_from:
+                  smtp_from: cloud-support@stfc.ac.uk
                   smtp_require_tls: false
 
                 route:

--- a/clusters/anish-monitoring-test/overrides/infra/deployment.yaml
+++ b/clusters/anish-monitoring-test/overrides/infra/deployment.yaml
@@ -27,6 +27,11 @@ openstack-cluster:
       kubePrometheusStack:
         release:
           values:
+            defaultRules:
+              additionalRuleLabels:
+                cluster: anish-monitoring-cluster
+                env: dev
+
             alertmanager:
               enabled: true
               service:
@@ -54,16 +59,16 @@ openstack-cluster:
                   smtp_require_tls: false
 
                 route:
-                  group_by: ['cluster', 'service']
-                  group_wait: 30m
-                  group_interval: 30m
-                  repeat_interval: 2d
                   receiver: 'null'
                   routes:
                     - receiver: 'null'
                       matchers:
                       - alertname = "Watchdog"
-                    - receiver: default-receiver
+                    - group_by: ['cluster', 'service']
+                      group_wait: 30m
+                      group_interval: 30m
+                      repeat_interval: 2d
+                      receiver: default-receiver
                       matchers:
                       - severity=~"critical|warning"
 
@@ -95,11 +100,11 @@ openstack-cluster:
                     send_resolved: true
                     headers:
                       subject: |
-                        {% raw %}
+                        {%- raw %}
                         "({{ .CommonLabels.env }} : {{ .CommonLabels.cluster }}) {{ .Status | toUpper }} {{ .CommonLabels.alertname }}"
-                        {% endraw %}
+                        {%- endraw %}
                     html: |-
-                      {% raw %}
+                      {%- raw %}
                       <h3>You have the following alerts:</h3>
                       {{ range .Alerts }}
                       <p><b>{{.Labels.alertname}}</b>
@@ -111,10 +116,10 @@ openstack-cluster:
                         {{ end }}</ul>
                         {{ .GeneratorURL }}</p>
                       {{ end }}
-                      {% endraw %}
+                      {%- endraw %}
 
                     text: |-
-                      {% raw %}
+                      {%- raw %}
                       You have the following alerts:
                       {{ range .Alerts }}
                       * {{.Labels.alertname}}
@@ -126,14 +131,14 @@ openstack-cluster:
                         {{ end }}
                         {{ .GeneratorURL }}
                       {{ end }}
-                      {% endraw %}
+                      {%- endraw %}
 
                 templates:
                   - '/etc/alertmanager/config/*.tmpl'
 
               alertmanagerSpec:
-                alertmanagerConfigMatcherStrategy: {}
-                alertmanagerConfigSelector: {}
+                alertmanagerConfigMatcherStrategy: null
+                alertmanagerConfigSelector: null
                 # turn off persistent storage so cinder volume doesn't get created
                 # TODO: remove this when cinder creation issue resolved          
                 storage: 

--- a/clusters/anish-monitoring-test/overrides/infra/deployment.yaml
+++ b/clusters/anish-monitoring-test/overrides/infra/deployment.yaml
@@ -36,12 +36,12 @@ openstack-cluster:
                 ingressClassName: nginx
                 enabled: true
                 hosts: 
-                  - alertmanager-test.staging.nubes.stfc.ac.uk
+                  - alertmanager.test.nubes.stfc.ac.uk
                 paths:
                   - "/"
                 tls: 
                   - hosts: 
-                    - alertmanager-test.staging.nubes.stfc.ac.uk
+                    - alertmanager.test.nubes.stfc.ac.uk
                     secretName: tls-keypair              
                 ingressPerReplica:
                   enabled: false
@@ -152,10 +152,10 @@ openstack-cluster:
                 enabled: true
                 path: /
                 hosts: 
-                  -  grafana-test.staging.nubes.stfc.ac.uk
+                  -  grafana.test.nubes.stfc.ac.uk
                 tls:
                   - hosts: 
-                    - "grafana-test.staging.nubes.stfc.ac.uk"
+                    - "grafana.test.nubes.stfc.ac.uk"
                     secretName: tls-keypair
 
 
@@ -174,10 +174,10 @@ openstack-cluster:
                 paths:
                   - /
                 hosts: 
-                  -  prometheus-test.staging.nubes.stfc.ac.uk
+                  -  prometheus.test.nubes.stfc.ac.uk
                 tls: 
                   - hosts: 
-                    - "prometheus-test.staging.nubes.stfc.ac.uk"
+                    - "prometheus.test.nubes.stfc.ac.uk"
                     secretName: tls-keypair
               
               prometheusSpec:


### PR DESCRIPTION
Enable KubePrometheusStack Addon for CAPI and configure emailing config
Tested on my child cluster `anish-monitoring-test`

You may notice that `charts/infra/capi/addons/monitoring.yaml` and `clusters/anish-monitoring-test/infra/deployment.yaml` have very similar config - this is because we cannot get `cloud-deployed-infra` to pick up the new values file for capi `charts/infra/capi/addons/monitoring.yaml` without pushing that file to `main` branch. 

TLDR: when reviewing this PR ignore all files in `clusters/anish-monitoring-test/` as they will be deleted anyway

 can't add a new file for capi as we are testing on a child cluster and cannot modify cloud-deployed-infra to point to our test branch so we have duplicated our monitoring config as cluster-specific config for our test cluster