### PR TITLE
BUG: Label nodes for longhorn values

### DIFF
--- a/clusters/david-harbor-test/overrides/infra/deployment.yaml
+++ b/clusters/david-harbor-test/overrides/infra/deployment.yaml
@@ -8,6 +8,8 @@ openstack-cluster:
 
   nodeGroupDefaults:
     machineFlavor: l3.tiny
+    nodeLabels:
+      longhorn.demo.io/longhorn-storage-node: true
 
   cloudCredentialsSecretName: david-prod-cloud-credentials
 


### PR DESCRIPTION
Label the nodes correctly so longhorn can use them