### PR TITLE
Changed default node labels

### DIFF
--- a/charts/apps/longhorn/values.yaml
+++ b/charts/apps/longhorn/values.yaml
@@ -16,7 +16,7 @@ longhorn:
 
   longhornManager:
     nodeSelector: 
-      longhorn.demo.io/longhorn-storage-node: "true"
+      longhorn.store.nodeselect/longhorn-storage-node: "true"
 
   defaultSettings:
     taintToleration: "nvidia.com/gpu:NoSchedule"

--- a/charts/infra/capi/values.yaml
+++ b/charts/infra/capi/values.yaml
@@ -26,6 +26,8 @@ openstack-cluster:
       machineCount: 2
 
   nodeGroupDefaults:
+    nodeLabels:
+      longhorn.store.nodeselect/longhorn-storage-node: true
     autoscale: false
     machineFlavor: l3.micro
 

--- a/docs/DEPLOYING_APPS.md
+++ b/docs/DEPLOYING_APPS.md
@@ -78,7 +78,7 @@ To deploy Longhorn we utilise the longhorn helm chart. See [Chart Repo](https://
 
 # Pre-deployment steps
 
-# 1. Label nodes to run longhorn on
+# 1. (Optional) Label nodes to run longhorn on
 
 Make sure you have labelled your nodes so that longhorn can use them as storage nodes. You want to label your worker nodes, the default label is `longhorn.demo.io/longhorn-storage-node=true` but you can change this in the cluster-specific values like so:	
 

--- a/docs/DEPLOYING_APPS.md
+++ b/docs/DEPLOYING_APPS.md
@@ -78,31 +78,7 @@ To deploy Longhorn we utilise the longhorn helm chart. See [Chart Repo](https://
 
 # Pre-deployment steps
 
-## 1. Label nodes to run longhorn on 
-
-Make sure you have labelled your nodes so that longhorn can use them as storage nodes. You want to label your worker nodes, the default label is `longhorn.demo.io/longhorn-storage-node=true` but you can change this in the cluster-specific values like so:
-
-```
-longhorn:
-  longhornManager:
-    nodeSelector: 
-      # change this to whatever label you want
-      longhorn.demo.io/longhorn-storage-node: "true"
-```
-
-**NOTE:** If you're using `capi` or any other `infra` that you're also managing with argocd - make sure you set these labels accordingly for your cluster. 
-
-For `capi` you can set node labels like so:
-
-```
-openstack-cluster:
-  nodeGroupDefaults:
-    nodeLabels:
-      # change this to whatever label you have set longhorn to use
-      longhorn.demo.io/longhorn-storage-node: true
-```
-
-# 2. (Optional) Add tls secret 
+# 1. (Optional) Add tls secret 
 
 Longhorn is configured to use TLS by default, by default it uses a self-signed certificate which is not secure - recommended to get a proper certificate for production systems.
 

--- a/docs/DEPLOYING_APPS.md
+++ b/docs/DEPLOYING_APPS.md
@@ -80,7 +80,13 @@ To deploy Longhorn we utilise the longhorn helm chart. See [Chart Repo](https://
 
 # 1. (Optional) Label nodes to run longhorn on
 
-Make sure you have labelled your nodes so that longhorn can use them as storage nodes. You want to label your worker nodes, the default label is `longhorn.demo.io/longhorn-storage-node=true` but you can change this in the cluster-specific values like so:	
+Make sure you have labelled your nodes so that longhorn can use them as storage nodes. 
+
+If you're also managing `capi`, these are set for you - so you don't need to do anything.  
+
+You want to label your worker nodes, the default label is `longhorn.store.nodeselect/longhorn-storage-node: "true`  
+
+You can change this in the cluster-specific values like so:	
 
 ```	
 longhorn:	

--- a/docs/DEPLOYING_APPS.md
+++ b/docs/DEPLOYING_APPS.md
@@ -92,7 +92,7 @@ longhorn:
 
 **NOTE:** If you're NOT using `capi` - make sure you set these labels accordingly for your cluster. 	
 
-For `capi` you can set node labels like so:	
+If you want to change the node labels that capi uses - you can do so like this: 
 
 ```	
 openstack-cluster:	

--- a/docs/DEPLOYING_APPS.md
+++ b/docs/DEPLOYING_APPS.md
@@ -90,7 +90,7 @@ longhorn:
       longhorn.store.nodeselect/longhorn-storage-node: true	
 ```	
 
-**NOTE:** If you're using `capi` or any other `infra` that you're also managing with argocd - make sure you set these labels accordingly for your cluster. 	
+**NOTE:** If you're NOT using `capi` - make sure you set these labels accordingly for your cluster. 	
 
 For `capi` you can set node labels like so:	
 

--- a/docs/DEPLOYING_APPS.md
+++ b/docs/DEPLOYING_APPS.md
@@ -78,7 +78,40 @@ To deploy Longhorn we utilise the longhorn helm chart. See [Chart Repo](https://
 
 # Pre-deployment steps
 
-# 1. (Optional) Add tls secret 
+# 1. Label nodes to run longhorn on
+
+Make sure you have labelled your nodes so that longhorn can use them as storage nodes. You want to label your worker nodes, the default label is `longhorn.demo.io/longhorn-storage-node=true` but you can change this in the cluster-specific values like so:	
+
+```	
+longhorn:	
+  longhornManager:	
+    nodeSelector: 	
+      # change this to whatever label you want	
+      longhorn.store.nodeselect/longhorn-storage-node: true	
+```	
+
+**NOTE:** If you're using `capi` or any other `infra` that you're also managing with argocd - make sure you set these labels accordingly for your cluster. 	
+
+For `capi` you can set node labels like so:	
+
+```	
+openstack-cluster:	
+  nodeGroupDefaults:	
+    nodeLabels:	
+      # change this to whatever label you have set longhorn to use	
+      longhorn.store.nodeselect/longhorn-storage-node: true
+```	
+
+# 2. (Optional) Add tls secret 	
+
+
+Longhorn is configured to use TLS by default, by default it uses a self-signed certificate which is not secure - recommended to get a proper certificate for production systems.	Longhorn is configured to use TLS by default, by default it uses a self-signed certificate which is not secure - recommended to get a proper certificate for production systems.
+
+
+Footer
+
+
+# 2. (Optional) Add tls secret 
 
 Longhorn is configured to use TLS by default, by default it uses a self-signed certificate which is not secure - recommended to get a proper certificate for production systems.
 


### PR DESCRIPTION

### Description:
Added a default node label to make nodes longhorn stores 
Changed docs to reflect this
<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- If this is a hotfix for production, which needs to be deployed after merging
- If this requires manual work to deploy the PR, e.g. a parameter change
- If this has associated internal documentation too
-->

---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
