### PR TITLE
MAINT: set cluster name for monitoring correctly

### DIFF
--- a/charts/infra/capi/addons/monitoring.yaml
+++ b/charts/infra/capi/addons/monitoring.yaml
@@ -10,7 +10,8 @@ openstack-cluster:
 
             defaultRules:
               additionalRuleLabels:
-                cluster: test-cluster
+                # these values used for alerting only - part of the email subject tag-line
+                cluster: not-set
                 env: dev
             
             alertmanager:

--- a/charts/infra/capi/addons/monitoring.yaml
+++ b/charts/infra/capi/addons/monitoring.yaml
@@ -10,7 +10,7 @@ openstack-cluster:
 
             defaultRules:
               additionalRuleLabels:
-                cluster: anish-monitoring-cluster
+                cluster: test-cluster
                 env: dev
             
             alertmanager:

--- a/charts/infra/capi/addons/monitoring.yaml
+++ b/charts/infra/capi/addons/monitoring.yaml
@@ -34,21 +34,22 @@ openstack-cluster:
 
               config:
                 global:
-                  resolve_timeout: 5m
+                  resolve_timeout: 1h
                   smtp_smarthost: 
                   smtp_from:
                   smtp_require_tls: false
 
                 route:
-                  group_wait: 30m
-                  group_interval: 30m
-                  repeat_interval: 2d
                   receiver: 'null'
                   routes:
                     - receiver: 'null'
                       matchers:
                       - alertname = "Watchdog"
                     - receiver: default-receiver
+                      group_wait: 30m
+                      group_interval: 30m
+                      repeat_interval: 2d
+                      group_by: ['cluster', 'service']
                       matchers:
                       - severity=~"critical|warning"
 

--- a/clusters/staging-management-cluster/overrides/infra/deployment.yaml
+++ b/clusters/staging-management-cluster/overrides/infra/deployment.yaml
@@ -25,6 +25,10 @@ openstack-cluster:
       kubePrometheusStack:
         release:
           values:
+            defaultRules:
+              additionalRuleLabels:
+                cluster: staging-management-cluster
+                env: dev
             alertmanager:
               enabled: true
               ingress:

--- a/docs/DEPLOYING_INFRA.md
+++ b/docs/DEPLOYING_INFRA.md
@@ -143,7 +143,7 @@ openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -keyout privateKey.k
 Then to create a secret from a cert - the secret name is for Prometheus, Alertmanager and Grafana is expected to be `tls-keypair` by default:
 
 ```
-kubectl create secret tls tls-keypair --cert certificate.crt --key pivateKey.key -n monitoring-system
+kubectl create secret tls tls-keypair --cert certificate.crt --key privateKey.key -n monitoring-system
 ```
 
 ## Optional Steps
@@ -160,11 +160,15 @@ openstack-cluster:
       kubePrometheusStack:
         release:
           values:
+            defaultRules:
+              additionalRuleLabels:
+                cluster: <name of cluster>
+                env: <dev/prod>
             alertmanager:
               enabled: true
 ```
 
-2. (optional) Change the ingress hostnames and or certs for monitoring endpoints
+1. (optional) Change the ingress hostnames for monitoring endpoints
 
 ```
 openstack-cluster:


### PR DESCRIPTION
cluster name and environment needs to be set correctly so it points to staging-management-cluster
