### PR TITLE
ENH: add prod-mgmt cluster

### DIFF
--- a/charts/argocd-apps/templates/cloud-deployed-apps.yaml
+++ b/charts/argocd-apps/templates/cloud-deployed-apps.yaml
@@ -10,7 +10,7 @@ spec:
   project: {{ $.Values.global.spec.project }}
   source:
     repoURL: {{ $.Values.global.spec.source.repoURL }}
-    targetRevision: {{ $.Values.global.spec.source.targetRevision }}
+    targetRevision: {{ default $.Values.global.spec.source.targetRevision $.Values.cloudDeployedApps.targetRevision }}
     path: charts/argocd-apps/
     helm:
       valueFiles:

--- a/charts/argocd-infra/templates/cloud-deployed-infra.yaml
+++ b/charts/argocd-infra/templates/cloud-deployed-infra.yaml
@@ -10,7 +10,7 @@ spec:
   project: {{ $.Values.global.spec.project }}
   source:
     repoURL: {{ $.Values.global.spec.source.repoURL }}
-    targetRevision: {{ $.Values.global.spec.source.targetRevision }}
+    targetRevision: {{ default $.Values.global.spec.source.targetRevision $.Values.cloudDeployedInfra.targetRevision }}
     path: charts/argocd-infra/
     helm:
       valueFiles:

--- a/charts/infra/capi/values.yaml
+++ b/charts/infra/capi/values.yaml
@@ -27,7 +27,7 @@ openstack-cluster:
 
   nodeGroupDefaults:
     autoscale: false
-    machineFlavor: l3.micro
+    machineFlavor: l3.nano
 
     healthCheck:
       enabled: true
@@ -45,11 +45,10 @@ openstack-cluster:
   additionalPackages: []
 
   controlPlane:
+    machineCount: 3
     remediationStrategy:
       retryPeriod: 20m0s
       minHealthyPeriod: 1h0m0s
-
-    machineCount: 5
     machineFlavor: l3.nano
 
   kubernetesVersion: "1.28.7"

--- a/charts/infra/capi/values.yaml
+++ b/charts/infra/capi/values.yaml
@@ -27,7 +27,7 @@ openstack-cluster:
 
   nodeGroupDefaults:
     autoscale: false
-    machineFlavor: l3.nano
+    machineFlavor: l3.micro
 
     healthCheck:
       enabled: true
@@ -45,7 +45,7 @@ openstack-cluster:
   additionalPackages: []
 
   controlPlane:
-    machineCount: 3
+    machineCount: 5
     remediationStrategy:
       retryPeriod: 20m0s
       minHealthyPeriod: 1h0m0s

--- a/clusters/prod-mgmt/app-values.yaml
+++ b/clusters/prod-mgmt/app-values.yaml
@@ -2,6 +2,6 @@ global:
   clusterName: prod-mgmt
   spec:
     source:
-      targetRevision: prod
+      targetRevision: main
       repoURL: https://github.com/stfc/cloud-deployed-apps.git
       namespace: argocd

--- a/clusters/prod-mgmt/app-values.yaml
+++ b/clusters/prod-mgmt/app-values.yaml
@@ -2,6 +2,11 @@ global:
   clusterName: prod-mgmt
   spec:
     source:
-      targetRevision: main
+      targetRevision: 000cf30993bd7fb191281ad3e5da7c4ddd95aba6
       repoURL: https://github.com/stfc/cloud-deployed-apps.git
       namespace: argocd
+
+# repoint cloud-deployed-apps application to point to main so we pick up latest changes
+# in case we move global targetRevision 
+cloudDeployedApps:
+  targetRevision: main

--- a/clusters/prod-mgmt/app-values.yaml
+++ b/clusters/prod-mgmt/app-values.yaml
@@ -2,6 +2,6 @@ global:
   clusterName: prod-mgmt
   spec:
     source:
-      targetRevision: main
+      targetRevision: prod
       repoURL: https://github.com/stfc/cloud-deployed-apps.git
       namespace: argocd

--- a/clusters/prod-mgmt/app-values.yaml
+++ b/clusters/prod-mgmt/app-values.yaml
@@ -1,0 +1,7 @@
+global:
+  clusterName: prod-mgmt
+  spec:
+    source:
+      targetRevision: main
+      repoURL: https://github.com/stfc/cloud-deployed-apps.git
+      namespace: argocd

--- a/clusters/prod-mgmt/argocd-values.yaml
+++ b/clusters/prod-mgmt/argocd-values.yaml
@@ -1,0 +1,3 @@
+argo-cd:
+  global:
+    domain: argocd-mgmt.prod.nubes.stfc.ac.uk

--- a/clusters/prod-mgmt/infra-values.yaml
+++ b/clusters/prod-mgmt/infra-values.yaml
@@ -2,7 +2,7 @@ global:
   clusterName: prod-mgmt
   spec:
     source:
-      targetRevision: prod
+      targetRevision: main
       repoURL: https://github.com/stfc/cloud-deployed-apps.git
       namespace: argocd
 

--- a/clusters/prod-mgmt/infra-values.yaml
+++ b/clusters/prod-mgmt/infra-values.yaml
@@ -2,7 +2,7 @@ global:
   clusterName: prod-mgmt
   spec:
     source:
-      targetRevision: main
+      targetRevision: prod
       repoURL: https://github.com/stfc/cloud-deployed-apps.git
       namespace: argocd
 

--- a/clusters/prod-mgmt/infra-values.yaml
+++ b/clusters/prod-mgmt/infra-values.yaml
@@ -1,0 +1,15 @@
+global:
+  clusterName: prod-mgmt
+  spec:
+    source:
+      targetRevision: main
+      repoURL: https://github.com/stfc/cloud-deployed-apps.git
+      namespace: argocd
+
+infra:
+  - name: prod-mgmt
+    disableAutomated: false
+    chartName: capi
+    namespace: clusters
+    additionalValueFiles:
+      - clusters/prod-mgmt/overrides/infra/deployment.yaml

--- a/clusters/prod-mgmt/infra-values.yaml
+++ b/clusters/prod-mgmt/infra-values.yaml
@@ -2,9 +2,14 @@ global:
   clusterName: prod-mgmt
   spec:
     source:
-      targetRevision: main
+      targetRevision: 000cf30993bd7fb191281ad3e5da7c4ddd95aba6
       repoURL: https://github.com/stfc/cloud-deployed-apps.git
       namespace: argocd
+
+# repoint cloud-deployed-infra application to point to main so we pick up latest changes
+# in case we move global targetRevision 
+cloudDeployedInfra:
+  targetRevision: main
 
 infra:
   - name: prod-mgmt

--- a/clusters/prod-mgmt/overrides/infra/deployment.yaml
+++ b/clusters/prod-mgmt/overrides/infra/deployment.yaml
@@ -1,13 +1,4 @@
 openstack-cluster:
-  controlPlane:
-    machineCount: 3
-
-  nodeGroups:
-    - name: default-md-0
-      machineCount: 2
-
-  nodeGroupDefaults:
-    machineFlavor: l3.nano
 
   cloudCredentialsSecretName: prod-mgmt-cloud-credentials
 

--- a/clusters/prod-mgmt/overrides/infra/deployment.yaml
+++ b/clusters/prod-mgmt/overrides/infra/deployment.yaml
@@ -25,6 +25,11 @@ openstack-cluster:
       kubePrometheusStack:
         release:
           values:
+            defaultRules:
+              additionalRuleLabels:
+                # these values used for alerting only - part of the email subject tag-line
+                cluster: prod-mgmt
+                env: prod
             alertmanager:
               enabled: true
               ingress:

--- a/clusters/prod-mgmt/overrides/infra/deployment.yaml
+++ b/clusters/prod-mgmt/overrides/infra/deployment.yaml
@@ -1,0 +1,52 @@
+openstack-cluster:
+  controlPlane:
+    machineCount: 3
+
+  nodeGroups:
+    - name: default-md-0
+      machineCount: 2
+
+  nodeGroupDefaults:
+    machineFlavor: l3.nano
+
+  cloudCredentialsSecretName: prod-mgmt-cloud-credentials
+
+  addons:
+    ingress:
+      enabled: true
+      nginx:
+        release:
+          values:
+            controller:
+              service:
+                loadBalancerIP: "130.246.81.161"
+
+    monitoring:
+      kubePrometheusStack:
+        release:
+          values:
+            alertmanager:
+              enabled: true
+              ingress:
+                hosts:
+                  - alertmanager-mgmt.prod.nubes.stfc.ac.uk
+                tls:
+                  - hosts: 
+                    - alertmanager-mgmt.prod.nubes.stfc.ac.uk
+                    secretName: tls-keypair
+            prometheus:
+              ingress:
+                hosts:
+                  - prometheus-mgmt.prod.nubes.stfc.ac.uk
+                tls:
+                  - hosts: 
+                    - prometheus-mgmt.prod.nubes.stfc.ac.uk
+                    secretName: tls-keypair
+            grafana:
+              ingress:
+                hosts:
+                  - grafana-mgmt.prod.nubes.stfc.ac.uk
+                tls:
+                  - hosts: 
+                    - grafana-mgmt.prod.nubes.stfc.ac.uk
+                    secretName: tls-keypair


### PR DESCRIPTION
### Description:
Add prod management cluster and make it self-managing

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [x] Verified this PR uses the correct label(s) based on the rules above?
* [x] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
