### PR TITLE
BUG: explicitly define externalNetworkID

### DIFF
--- a/clusters/prod-mgmt/overrides/infra/deployment.yaml
+++ b/clusters/prod-mgmt/overrides/infra/deployment.yaml
@@ -2,6 +2,9 @@ openstack-cluster:
 
   cloudCredentialsSecretName: prod-mgmt-cloud-credentials
 
+  clusterNetworking:
+    externalNetworkId: 5283f642-8bd8-48b6-8608-fa3006ff4539 # Prod External network ID
+
   addons:
     ingress:
       enabled: true

--- a/clusters/staging-management-cluster/overrides/infra/deployment.yaml
+++ b/clusters/staging-management-cluster/overrides/infra/deployment.yaml
@@ -9,6 +9,9 @@ openstack-cluster:
   nodeGroupDefaults:
     machineFlavor: l3.nano
 
+  clusterNetworking:
+    externalNetworkId: 0dc30001-edfb-4137-be76-8e51f38fd650 # Dev External network ID
+
   cloudCredentialsSecretName: staging-management-cluster-cloud-credentials
 
   addons:

--- a/clusters/staging-worker/overrides/infra/deployment.yaml
+++ b/clusters/staging-worker/overrides/infra/deployment.yaml
@@ -9,6 +9,9 @@ openstack-cluster:
   nodeGroupDefaults:
     machineFlavor: l3.micro
 
+  clusterNetworking:
+    externalNetworkId: 0dc30001-edfb-4137-be76-8e51f38fd650 # Dev External network ID
+
   cloudCredentialsSecretName: staging-management-cluster-cloud-credentials
 
   addons:

--- a/clusters/victoria-metrics-test/overrides/infra/deployment.yaml
+++ b/clusters/victoria-metrics-test/overrides/infra/deployment.yaml
@@ -9,6 +9,9 @@ openstack-cluster:
   nodeGroupDefaults:
     machineFlavor: l3.nano
 
+  clusterNetworking:
+    externalNetworkId: 0dc30001-edfb-4137-be76-8e51f38fd650 # Dev External network ID
+
   cloudCredentialsSecretName: victoria-metrics-test-cloud-credentials
 
   addons:

--- a/docs/DEPLOYING_INFRA.md
+++ b/docs/DEPLOYING_INFRA.md
@@ -109,6 +109,15 @@ openstack-cluster:
 
 **NOTE: we cannot specify the child cluster to use specific floating ips yet - this requires an upstream fix to allow setting these attributes from secrets.**
 
+4. Set the external network ID for either prod or dev openstack
+Edit the file `clusters/<cluster-name>/overrides/infra/deployment.yaml`:
+```
+openstack-cluster:
+  externalNetworkId: # "External" network ID
+```
+You can find the "External" network's ID by looking in "Networks" on the openstack UI and cicking on the "External" network - the value for `ID` is what you want  
+
+
 ## Setup Nginx Ingress and TLS
 
 1. Specify FIP for Nginx Ingress


### PR DESCRIPTION
### Description:
if the project has multiple external networks - cluster deployment fails - we need to explicitly define the "id" of the network we want to use for each cluster

**NOTE**: This will require us to re-make all of our clusters because this is a protected field and can't be changed on running clusters 

---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
