### PR TITLE
make prod-mgmt use prod tag for tracking

### DIFF
--- a/clusters/prod-mgmt/infra-values.yaml
+++ b/clusters/prod-mgmt/infra-values.yaml
@@ -2,7 +2,7 @@ global:
   clusterName: prod-mgmt
   spec:
     source:
-      targetRevision: 000cf30993bd7fb191281ad3e5da7c4ddd95aba6
+      targetRevision: prod-v1.0.0 # commit that fixes external ID 
       repoURL: https://github.com/stfc/cloud-deployed-apps.git
       namespace: argocd
 

--- a/clusters/prod-mgmt/infra-values.yaml
+++ b/clusters/prod-mgmt/infra-values.yaml
@@ -2,7 +2,7 @@ global:
   clusterName: prod-mgmt
   spec:
     source:
-      targetRevision: prod-v1.0.0 # commit that fixes external ID 
+      targetRevision: prod-v1.0.0 # commit that fixes external network ID for capi
       repoURL: https://github.com/stfc/cloud-deployed-apps.git
       namespace: argocd
 


### PR DESCRIPTION
updating prod to point to updated commit/tag which fixes external network id 