### PR TITLE
ENH: make prod-mgmt manage a new VM prod cluster

### DIFF
--- a/clusters/prod-mgmt/app-values.yaml
+++ b/clusters/prod-mgmt/app-values.yaml
@@ -2,7 +2,7 @@ global:
   clusterName: prod-mgmt
   spec:
     source:
-      targetRevision: prod-v1.0.0
+      targetRevision: prod-v1.0.1-vm
       repoURL: https://github.com/stfc/cloud-deployed-apps.git
       namespace: argocd
 

--- a/clusters/prod-mgmt/app-values.yaml
+++ b/clusters/prod-mgmt/app-values.yaml
@@ -2,11 +2,6 @@ global:
   clusterName: prod-mgmt
   spec:
     source:
-      targetRevision: prod-v1.0.1-vm
+      targetRevision: main
       repoURL: https://github.com/stfc/cloud-deployed-apps.git
       namespace: argocd
-
-# repoint cloud-deployed-apps application to point to main so we pick up latest changes
-# in case we move global targetRevision 
-cloudDeployedApps:
-  targetRevision: main

--- a/clusters/prod-mgmt/infra-values.yaml
+++ b/clusters/prod-mgmt/infra-values.yaml
@@ -2,7 +2,7 @@ global:
   clusterName: prod-mgmt
   spec:
     source:
-      targetRevision: prod-v1.0.0
+      targetRevision: prod-v1.0.1-vm
       repoURL: https://github.com/stfc/cloud-deployed-apps.git
       namespace: argocd
 
@@ -18,3 +18,10 @@ infra:
     namespace: clusters
     additionalValueFiles:
       - clusters/prod-mgmt/overrides/infra/deployment.yaml
+
+  - name: victoria-metrics-prod
+    disableAutomated: false
+    chartName: capi
+    namespace: clusters
+    additionalValueFiles:
+      - clusters/victoria-metrics-prod/overrides/infra/deployment.yaml

--- a/clusters/prod-mgmt/infra-values.yaml
+++ b/clusters/prod-mgmt/infra-values.yaml
@@ -2,14 +2,9 @@ global:
   clusterName: prod-mgmt
   spec:
     source:
-      targetRevision: prod-v1.0.1-vm
+      targetRevision: main
       repoURL: https://github.com/stfc/cloud-deployed-apps.git
       namespace: argocd
-
-# repoint cloud-deployed-infra application to point to main so we pick up latest changes
-# in case we move global targetRevision 
-cloudDeployedInfra:
-  targetRevision: main
 
 infra:
   - name: prod-mgmt

--- a/clusters/victoria-metrics-prod/app-values.yaml
+++ b/clusters/victoria-metrics-prod/app-values.yaml
@@ -5,13 +5,16 @@ global:
 
   spec:
     source:
-      targetRevision: victoria-metrics-pr
+      targetRevision: prod-v1.0.1-vm
 
       # change this if you're using a fork
       repoURL: https://github.com/stfc/cloud-deployed-apps.git
 
       # namespace where the argocd applications will be installed to
       namespace: argocd
+
+cloudDeployedApps:
+  targetRevision: main
 
 apps:
   - name: victoria-metrics-prod

--- a/clusters/victoria-metrics-prod/app-values.yaml
+++ b/clusters/victoria-metrics-prod/app-values.yaml
@@ -5,16 +5,13 @@ global:
 
   spec:
     source:
-      targetRevision: prod-v1.0.1-vm
+      targetRevision: main
 
       # change this if you're using a fork
       repoURL: https://github.com/stfc/cloud-deployed-apps.git
 
       # namespace where the argocd applications will be installed to
       namespace: argocd
-
-cloudDeployedApps:
-  targetRevision: main
 
 apps:
   - name: victoria-metrics-prod


### PR DESCRIPTION
### Description:

since this is a prod-change we are going to need to create a tag prod-v1.0.1-vm as soon as this is merged 

---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
