### PR TITLE
make prod clusters follow prod tag

### DIFF
--- a/clusters/prod-mgmt/app-values.yaml
+++ b/clusters/prod-mgmt/app-values.yaml
@@ -2,6 +2,6 @@ global:
   clusterName: prod-mgmt
   spec:
     source:
-      targetRevision: ee416c990aa8c5ced5469a854066985319e9b147
+      targetRevision: prod
       repoURL: https://github.com/stfc/cloud-deployed-apps.git
       namespace: argocd

--- a/clusters/prod-mgmt/infra-values.yaml
+++ b/clusters/prod-mgmt/infra-values.yaml
@@ -2,7 +2,7 @@ global:
   clusterName: prod-mgmt
   spec:
     source:
-      targetRevision: ee416c990aa8c5ced5469a854066985319e9b147
+      targetRevision: prod
       repoURL: https://github.com/stfc/cloud-deployed-apps.git
       namespace: argocd
 

--- a/clusters/victoria-metrics-prod/app-values.yaml
+++ b/clusters/victoria-metrics-prod/app-values.yaml
@@ -5,7 +5,7 @@ global:
 
   spec:
     source:
-      targetRevision: ee416c990aa8c5ced5469a854066985319e9b147
+      targetRevision: prod
 
       # change this if you're using a fork
       repoURL: https://github.com/stfc/cloud-deployed-apps.git


### PR DESCRIPTION
commit SHAs don't work - we'll go back to the original - we'll make a prod tag on the latest commit and deploy it off of that - we lose CI - and need to manually run deploy for now 