### PR TITLE
DEPLOY: Add training Jupyterhub on prod

### DIFF
--- a/clusters/jupyter-training/app-values.yaml
+++ b/clusters/jupyter-training/app-values.yaml
@@ -1,0 +1,1 @@
+# Managed through old Ansible mechanism currently

--- a/clusters/jupyter-training/overrides/infra/deployment.yaml
+++ b/clusters/jupyter-training/overrides/infra/deployment.yaml
@@ -1,0 +1,25 @@
+openstack-cluster:
+  controlPlane:
+    machineCount: 5
+
+  nodeGroups:
+    - name: default-md-0
+      machineCount: 2
+    - name: md-a4000-ref
+      machineCount: 20
+      machineFlavor: g-a4000-ref.x1
+    - name: md-rtx4000
+      machineCount: 40
+      machineFlavor: g-rtx4000-ref.x1
+    - name: md-a4000
+      machineCount: 25
+      machineFlavor: g-a4000.x1
+
+  nodeGroupDefaults:
+    machineFlavor: l3.tiny
+
+  # you must provide this for it to work
+  # - if this is for self-managing its <cluster-name>-cloud-credentials and can be found in the cluster namespace
+  # - if this is for setting up child cluster you can provide your own credentials secret or use the same one
+  # kubectl get secrets -n clusters
+  cloudCredentialsSecretName: jupyter-training-cloud-credentials

--- a/clusters/prod-mgmt/infra-values.yaml
+++ b/clusters/prod-mgmt/infra-values.yaml
@@ -14,6 +14,13 @@ infra:
     additionalValueFiles:
       - clusters/prod-mgmt/overrides/infra/deployment.yaml
 
+  - name: jupyter-training
+    disableAutomated: false
+    chartName: capi
+    namespace: clusters
+    additionalValueFiles:
+      - clusters/jupyter-training/overrides/infra/deployment.yaml
+
   - name: victoria-metrics-prod
     disableAutomated: false
     chartName: capi


### PR DESCRIPTION
### Description:

Adds the cluster infra for our training Jupyterhub, this will just manage the infra since we haven't tested deploying JHub via argo yet unlike the infra which is well-tested at this point


### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- If this is a hotfix for production, which needs to be deployed after merging
- If this requires manual work to deploy the PR, e.g. a parameter change
- If this has associated internal documentation too
-->

---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
