### PR TITLE
MAINT: Change size of GPU nodegroups

### DIFF
--- a/clusters/jupyter-training/overrides/infra/deployment.yaml
+++ b/clusters/jupyter-training/overrides/infra/deployment.yaml
@@ -9,10 +9,10 @@ openstack-cluster:
       machineCount: 20
       machineFlavor: g-a4000-ref.x1
     - name: md-rtx4000
-      machineCount: 40
+      machineCount: 35
       machineFlavor: g-rtx4000-ref.x1
     - name: md-a4000
-      machineCount: 25
+      machineCount: 30
       machineFlavor: g-a4000.x1
 
   nodeGroupDefaults:


### PR DESCRIPTION
### Description:

This PR changes the number of GPUs in each node group.

---

### Submitter:

Have you:

* [ ] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
