### PR TITLE
MAINT: Drop network UUIDs

### DIFF
--- a/clusters/prod-mgmt/overrides/infra/deployment.yaml
+++ b/clusters/prod-mgmt/overrides/infra/deployment.yaml
@@ -2,9 +2,6 @@ openstack-cluster:
 
   cloudCredentialsSecretName: prod-mgmt-cloud-credentials
 
-  clusterNetworking:
-    externalNetworkId: 5283f642-8bd8-48b6-8608-fa3006ff4539 # Prod External network ID
-
   addons:
     ingress:
       enabled: true

--- a/clusters/prod-worker/overrides/infra/deployment.yaml
+++ b/clusters/prod-worker/overrides/infra/deployment.yaml
@@ -1,7 +1,4 @@
 openstack-cluster:
-  clusterNetworking:
-    externalNetworkId: 5283f642-8bd8-48b6-8608-fa3006ff4539 # Prod External network ID
-
   cloudCredentialsSecretName: prod-mgmt-cloud-credentials
 
   addons:

--- a/clusters/staging-management-cluster/overrides/infra/deployment.yaml
+++ b/clusters/staging-management-cluster/overrides/infra/deployment.yaml
@@ -9,9 +9,6 @@ openstack-cluster:
   nodeGroupDefaults:
     machineFlavor: l3.nano
 
-  clusterNetworking:
-    externalNetworkId: 0dc30001-edfb-4137-be76-8e51f38fd650 # Dev External network ID
-
   cloudCredentialsSecretName: staging-management-cluster-cloud-credentials
 
   addons:

--- a/clusters/staging-worker/overrides/infra/deployment.yaml
+++ b/clusters/staging-worker/overrides/infra/deployment.yaml
@@ -9,9 +9,6 @@ openstack-cluster:
   nodeGroupDefaults:
     machineFlavor: l3.micro
 
-  clusterNetworking:
-    externalNetworkId: 0dc30001-edfb-4137-be76-8e51f38fd650 # Dev External network ID
-
   cloudCredentialsSecretName: staging-management-cluster-cloud-credentials
 
   addons:

--- a/clusters/victoria-metrics-test/overrides/infra/deployment.yaml
+++ b/clusters/victoria-metrics-test/overrides/infra/deployment.yaml
@@ -9,9 +9,6 @@ openstack-cluster:
   nodeGroupDefaults:
     machineFlavor: l3.nano
 
-  clusterNetworking:
-    externalNetworkId: 0dc30001-edfb-4137-be76-8e51f38fd650 # Dev External network ID
-
   cloudCredentialsSecretName: victoria-metrics-test-cloud-credentials
 
   addons:

--- a/clusters/vm-prod/overrides/infra/deployment.yaml
+++ b/clusters/vm-prod/overrides/infra/deployment.yaml
@@ -11,9 +11,6 @@ openstack-cluster:
 
   cloudCredentialsSecretName: victoria-metrics-test-cloud-credentials
 
-  clusterNetworking:
-    externalNetworkId: 5283f642-8bd8-48b6-8608-fa3006ff4539 # Prod External network ID
-
   addons:
     ingress:
       enabled: true

--- a/docs/DEPLOYING_INFRA.md
+++ b/docs/DEPLOYING_INFRA.md
@@ -109,15 +109,6 @@ openstack-cluster:
 
 **NOTE: we cannot specify the child cluster to use specific floating ips yet - this requires an upstream fix to allow setting these attributes from secrets.**
 
-4. Set the external network ID for either prod or dev openstack
-Edit the file `clusters/<cluster-name>/overrides/infra/deployment.yaml`:
-```
-openstack-cluster:
-  externalNetworkId: # "External" network ID
-```
-You can find the "External" network's ID by looking in "Networks" on the openstack UI and cicking on the "External" network - the value for `ID` is what you want  
-
-
 ## Setup Nginx Ingress and TLS
 
 1. Specify FIP for Nginx Ingress


### PR DESCRIPTION
### Description:

There should only be a single network called External. The UUID approach was a hang-over from the fact dev-openstack had a superflous network created within the project.

Revert this back to use the External network everywhere by default.

<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Special Notes:

Note: Since prod is pinned to a tag, this will not impact us until we move the tag forward. Where we will need to re-deploy pointing to the External network. This is a downside of specifying the UUID of the net

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- If this is a hotfix for production, which needs to be deployed after merging
- If this requires manual work to deploy the PR, e.g. a parameter change
- If this has associated internal documentation too
-->

---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [x] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
