### PR TITLE
MAINT: setup monitoring on staging-worker

### DIFF
--- a/clusters/staging-worker/overrides/infra/deployment.yaml
+++ b/clusters/staging-worker/overrides/infra/deployment.yaml
@@ -19,5 +19,38 @@ openstack-cluster:
           values:
             controller:
               service:
-                # Temporary for testing DR scenario
-                loadBalancerIP: "130.246.211.226"
+                loadBalancerIP: "130.246.211.106"
+    
+    kubePrometheusStack:
+      release:
+        values:
+          defaultRules:
+            additionalRuleLabels:
+              # these values used for alerting only - part of the email subject tag-line
+              cluster: staging-worker
+              env: dev
+          alertmanager:
+            enabled: true
+            ingress:
+              hosts:
+                - alertmanager-worker.staging.nubes.stfc.ac.uk
+              tls:
+                - hosts: 
+                  - alertmanager-worker.staging.nubes.stfc.ac.uk
+                  secretName: tls-keypair
+          prometheus:
+            ingress:
+              hosts:
+                - prometheus-worker.staging.nubes.stfc.ac.uk
+              tls:
+                - hosts: 
+                  - prometheus-worker.staging.nubes.stfc.ac.uk
+                  secretName: tls-keypair
+          grafana:
+            ingress:
+              hosts:
+                - grafana-worker.staging.nubes.stfc.ac.uk
+              tls:
+                - hosts: 
+                  - grafana-worker.staging.nubes.stfc.ac.uk
+                  secretName: tls-keypair


### PR DESCRIPTION
### Description:
setup monitoring and use updated floating ip for ingress as the previous floating ip doesn't seem to exist anymore

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- If this is a hotfix for production, which needs to be deployed after merging
- If this requires manual work to deploy the PR, e.g. a parameter change
- If this has associated internal documentation too
-->

---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
