### PR TITLE
DEPLOY: Remove infra from testing PR

### DIFF
--- a/clusters/david-pr-test/app-values.yaml
+++ b/clusters/david-pr-test/app-values.yaml
@@ -1,7 +1,0 @@
-global:
-  clusterName: david-pr-test
-  spec:
-    source:
-      targetRevision: Add_cert_manager
-      repoURL: https://github.com/stfc/cloud-deployed-apps.git
-      namespace: argocd

--- a/clusters/david-pr-test/overrides/infra/deployment.yaml
+++ b/clusters/david-pr-test/overrides/infra/deployment.yaml
@@ -1,6 +1,0 @@
-openstack-cluster:
-  cloudCredentialsSecretName: david-cloud-credentials
-
-  addons:
-    ingress:
-      enabled: false

--- a/clusters/staging-management-cluster/infra-values.yaml
+++ b/clusters/staging-management-cluster/infra-values.yaml
@@ -28,13 +28,6 @@ infra:
     additionalValueFiles:
       - clusters/david-harbor-test/overrides/infra/deployment.yaml
 
-  - name: david-pr-test
-    disableAutomated: false
-    chartName: capi
-    namespace: clusters
-    additionalValueFiles:
-      - clusters/david-pr-test/overrides/infra/deployment.yaml
-
   - name: vm-stage
     disableAutomated: false
     chartName: capi


### PR DESCRIPTION
### Description:

This was used as a deployment target for various PRs including cert bot. Now they've been merge drop the cluster from our list of staging infra targets.


### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- If this is a hotfix for production, which needs to be deployed after merging
- If this requires manual work to deploy the PR, e.g. a parameter change
- If this has associated internal documentation too
-->

---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
