### PR TITLE
MAINT: use cert-manager for self-signed certs for Monitoring

### DIFF
--- a/charts/infra/capi/addons/monitoring.yaml
+++ b/charts/infra/capi/addons/monitoring.yaml
@@ -20,16 +20,16 @@ openstack-cluster:
                 type: ClusterIP
               
               ingress:
+                annotations:
+                  cert-manager.io/cluster-issuer: "self-signed"
+                
                 ingressClassName: nginx
                 enabled: true
                 hosts: 
                   -  alertmanager.example.com
                 paths:
                   - "/"
-                tls: 
-                  - hosts: 
-                    - "alertmanager.example.com"
-                    secretName: tls-keypair
+
                 ingressPerReplica:
                   enabled: false
 
@@ -143,16 +143,14 @@ openstack-cluster:
                 type: ClusterIP
               
               ingress:
+                annotations:
+                  cert-manager.io/cluster-issuer: "self-signed"
+                
                 ingressClassName: nginx
                 enabled: true
                 path: /
                 hosts: 
                   -  grafana.example.com
-                tls:
-                  - hosts: 
-                    - "grafana.example.com"
-                    secretName: tls-keypair
-
 
             prometheus-operator:
               enabled: true
@@ -164,16 +162,14 @@ openstack-cluster:
                 type: ClusterIP
 
               ingress:
+                annotations:
+                  cert-manager.io/cluster-issuer: "self-signed"
                 ingressClassName: nginx
                 enabled: true
                 paths:
                   - /
                 hosts: 
                   -  prometheus.example.com
-                tls: 
-                  - hosts: 
-                    - "prometheus.example.com"
-                    secretName: tls-keypair
               
               prometheusSpec:
                 # turn off persistent storage so cinder volume doesn't get created

--- a/clusters/jupyter-training/overrides/infra/deployment.yaml
+++ b/clusters/jupyter-training/overrides/infra/deployment.yaml
@@ -37,6 +37,7 @@ openstack-cluster:
           alertmanager:
             enabled: true
             ingress:
+              annotations: ""
               hosts:
                 - alertmanager-jupyter-training.prod.nubes.stfc.ac.uk
               tls:
@@ -45,6 +46,7 @@ openstack-cluster:
                   secretName: tls-keypair
           prometheus:
             ingress:
+              annotations: ""
               hosts:
                 - prometheus-jupyter-training.prod.nubes.stfc.ac.uk
               tls:
@@ -53,6 +55,7 @@ openstack-cluster:
                   secretName: tls-keypair
           grafana:
             ingress:
+              annotations: ""
               hosts:
                 - grafana-jupyter-training.prod.nubes.stfc.ac.uk
               tls:

--- a/clusters/prod-mgmt/overrides/infra/deployment.yaml
+++ b/clusters/prod-mgmt/overrides/infra/deployment.yaml
@@ -24,6 +24,7 @@ openstack-cluster:
             alertmanager:
               enabled: true
               ingress:
+                annotations: ""
                 hosts:
                   - alertmanager-mgmt.prod.nubes.stfc.ac.uk
                 tls:
@@ -32,6 +33,7 @@ openstack-cluster:
                     secretName: tls-keypair
             prometheus:
               ingress:
+                annotations: ""
                 hosts:
                   - prometheus-mgmt.prod.nubes.stfc.ac.uk
                 tls:
@@ -40,6 +42,7 @@ openstack-cluster:
                     secretName: tls-keypair
             grafana:
               ingress:
+                annotations: ""
                 hosts:
                   - grafana-mgmt.prod.nubes.stfc.ac.uk
                 tls:

--- a/clusters/prod-worker/overrides/infra/deployment.yaml
+++ b/clusters/prod-worker/overrides/infra/deployment.yaml
@@ -14,6 +14,7 @@ openstack-cluster:
             alertmanager:
               enabled: true
               ingress:
+                annotations: ""
                 hosts:
                   - alertmanager-worker.prod.nubes.stfc.ac.uk
                 tls:
@@ -22,6 +23,7 @@ openstack-cluster:
                     secretName: tls-keypair
             prometheus:
               ingress:
+                annotations: ""
                 hosts:
                   - prometheus-worker.prod.nubes.stfc.ac.uk
                 tls:
@@ -30,6 +32,7 @@ openstack-cluster:
                     secretName: tls-keypair
             grafana:
               ingress:
+                annotations: ""
                 hosts:
                   - grafana-worker.prod.nubes.stfc.ac.uk
                 tls:

--- a/clusters/staging-management-cluster/overrides/infra/deployment.yaml
+++ b/clusters/staging-management-cluster/overrides/infra/deployment.yaml
@@ -32,6 +32,7 @@ openstack-cluster:
             alertmanager:
               enabled: true
               ingress:
+                annotations: ""
                 hosts:
                   - alertmanager-mgmt.staging.nubes.stfc.ac.uk
                 tls:
@@ -40,6 +41,7 @@ openstack-cluster:
                     secretName: tls-keypair
             prometheus:
               ingress:
+                annotations: ""
                 hosts:
                   - prometheus-mgmt.staging.nubes.stfc.ac.uk
                 tls:
@@ -48,6 +50,7 @@ openstack-cluster:
                     secretName: tls-keypair
             grafana:
               ingress:
+                annotations: ""
                 hosts:
                   - grafana-mgmt.staging.nubes.stfc.ac.uk
                 tls:

--- a/clusters/staging-worker/overrides/infra/deployment.yaml
+++ b/clusters/staging-worker/overrides/infra/deployment.yaml
@@ -32,6 +32,7 @@ openstack-cluster:
           alertmanager:
             enabled: true
             ingress:
+              annotations: ""
               hosts:
                 - alertmanager-worker.staging.nubes.stfc.ac.uk
               tls:
@@ -40,6 +41,7 @@ openstack-cluster:
                   secretName: tls-keypair
           prometheus:
             ingress:
+              annotations: ""
               hosts:
                 - prometheus-worker.staging.nubes.stfc.ac.uk
               tls:
@@ -48,6 +50,7 @@ openstack-cluster:
                   secretName: tls-keypair
           grafana:
             ingress:
+              annotations: ""
               hosts:
                 - grafana-worker.staging.nubes.stfc.ac.uk
               tls:


### PR DESCRIPTION
Now that we have cert-manager as a dependency chart - we should use its self-signed cert capabilities for setting up tls for monitoring stack.

For clusters which have already been setup with manual tls certs - override the annotation for setting up self-signed cert using cert-manager

To test this - I want to deploy this to staging and see if vm-stage no longer complains about missing certs

