### PR TITLE
MAINT: remove setting cluster networking

### DIFF
--- a/charts/infra/capi/networking.yaml
+++ b/charts/infra/capi/networking.yaml
@@ -11,9 +11,6 @@ openstack-cluster:
         - 10.8.0.0/13
     serviceDomain: cluster.local
 
-  clusterNetworking:
-    externalNetworkId: External
-
   registryMirrors: { docker.io: ["https://dockerhub.stfc.ac.uk"] }
 
   apiServer:


### PR DESCRIPTION
This is a bug and needs to be removed since its looking for an ID and not a name

This shouldn't have any affect on clusters already made