### PR TITLE
MAINT: Bump argo-cd helm version to 6.10.2

### DIFF
--- a/charts/argocd/Chart.yaml
+++ b/charts/argocd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: argocd
-version: 1.0.0
+version: 1.0.1
 dependencies:
 - name: argo-cd
-  version: 6.7.7
+  version: 6.10.2
   repository: https://argoproj.github.io/argo-helm
   


### PR DESCRIPTION
### Description:

Update to use the latest ArgoCD helm chart

---

### Submitter:

Have you:

* [ ] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
