### PR TITLE
Fix appset invalid preserve

### DIFF
--- a/clusters/dev/management/apps.yaml
+++ b/clusters/dev/management/apps.yaml
@@ -13,7 +13,6 @@ spec:
     targetRevision: folder_flows
     path: clusters/dev/management
   syncPolicy:
-    preserveResourcesOnDeletion: true
     automated:
       prune: false
       selfHeal: true

--- a/clusters/dev/management/apps.yaml
+++ b/clusters/dev/management/apps.yaml
@@ -54,13 +54,6 @@ spec:
   syncPolicy:
     # Don't remove everything if we remove the appset
     preserveResourcesOnDeletion: true
-    automated:
-      # apps are easy to re-deploy, a git revert will bring it back
-      prune: true
-      selfHeal: true
-      allowEmpty: true
-    syncOptions:
-      - CreateNamespace=true
 
   template:
     metadata:
@@ -103,13 +96,7 @@ spec:
           - path: "clusters/dev/*/infra-values.yaml"
   syncPolicy:
     preserveResourcesOnDeletion: true
-    automated:
-      # Infra requires more effort to re-deploy, so don't prune automatically
-      prune: false
-      selfHeal: true
-      allowEmpty: true
-    syncOptions:
-      - CreateNamespace=true
+
   template:
     metadata:
       name: "{{path.basename}}-cluster"

--- a/clusters/dev/management/apps.yaml
+++ b/clusters/dev/management/apps.yaml
@@ -13,7 +13,7 @@ spec:
     targetRevision: folder_flows
     path: clusters/dev/management
   syncPolicy:
-    preserveResourcesOnDeletion: true     
+    preserveResourcesOnDeletion: true
     automated:
       prune: false
       selfHeal: true
@@ -22,38 +22,37 @@ spec:
       - CreateNamespace=true
 
 ---
-
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
-    name: management-apps
-    namespace: argocd
+  name: management-apps
+  namespace: argocd
 spec:
   generators:
     - list:
         elements:
-        - name: "argocd"
-          chartName: argocd
+          - name: "argocd"
+            chartName: argocd
 
-          # NOTE: each chart needs a valuesFile for this to work 
-          # so create one for each chart - even if its empty
-          
-          # argocd and all dependencies use the same file "argocd-setup-values.yaml" 
-          valuesFile: ../../../clusters/dev/management/argocd-setup-values.yaml
-          namespace: argocd
+            # NOTE: each chart needs a valuesFile for this to work
+            # so create one for each chart - even if its empty
 
-        - name: "cert-manager"
-          chartName: cert-manager
-          namespace: cert-manager
-          valuesFile: ../../../clusters/dev/management/argocd-setup-values.yaml
+            # argocd and all dependencies use the same file "argocd-setup-values.yaml"
+            valuesFile: ../../../clusters/dev/management/argocd-setup-values.yaml
+            namespace: argocd
 
-        - name: cluster-api-addon-provider
-          chartName: cluster-api-addon-provider
-          namespace: clusters
-          valuesFile: ../../../clusters/dev/management/argocd-setup-values.yaml
+          - name: "cert-manager"
+            chartName: cert-manager
+            namespace: cert-manager
+            valuesFile: ../../../clusters/dev/management/argocd-setup-values.yaml
+
+          - name: cluster-api-addon-provider
+            chartName: cluster-api-addon-provider
+            namespace: clusters
+            valuesFile: ../../../clusters/dev/management/argocd-setup-values.yaml
 
   syncPolicy:
-    preserveResourcesOnDeletion: true 
+    preserveResourcesOnDeletion: true
     automated:
       prune: true
       selfHeal: true
@@ -62,34 +61,33 @@ spec:
       - CreateNamespace=true
 
   template:
-      metadata:
-        name: '{{name}}'
-        namespace: argocd
-      spec:
-        project: default
-        source:
-          repoURL: "https://github.com/stfc/cloud-deployed-apps.git"
-          targetRevision: folder_flows
-          path: "charts/dev/{{chartName}}"
-          helm:
-            valueFiles:
-              - "{{valuesFile}}"
-        destination:
-            server: https://kubernetes.default.svc
-            namespace: "{{namespace}}"
-        
-        # apps are easy to deploy - so we can cascade delete them
-        syncPolicy:
-          preserveResourcesOnDeletion: false  
-          automated:
-            prune: true
-            selfHeal: true
-            allowEmpty: true
-          syncOptions:
-            - CreateNamespace=true
+    metadata:
+      name: "{{name}}"
+      namespace: argocd
+    spec:
+      project: default
+      source:
+        repoURL: "https://github.com/stfc/cloud-deployed-apps.git"
+        targetRevision: folder_flows
+        path: "charts/dev/{{chartName}}"
+        helm:
+          valueFiles:
+            - "{{valuesFile}}"
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: "{{namespace}}"
+
+      # apps are easy to deploy - so we can cascade delete them
+      syncPolicy:
+        preserveResourcesOnDeletion: false
+        automated:
+          prune: true
+          selfHeal: true
+          allowEmpty: true
+        syncOptions:
+          - CreateNamespace=true
 
 ---
-
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
@@ -101,10 +99,10 @@ spec:
         repoURL: "https://github.com/stfc/cloud-deployed-apps.git"
         revision: folder_flows
         files:
-        # grab all infra values for all clusters in environment
-        - path: "clusters/dev/*/infra-values.yaml"
+          # grab all infra values for all clusters in environment
+          - path: "clusters/dev/*/infra-values.yaml"
   syncPolicy:
-    preserveResourcesOnDeletion: true     
+    preserveResourcesOnDeletion: true
     automated:
       prune: false
       selfHeal: true
@@ -113,7 +111,7 @@ spec:
       - CreateNamespace=true
   template:
     metadata:
-      name: '{{path.basename}}-cluster'
+      name: "{{path.basename}}-cluster"
       # All applications need to go into the ArgoCD namespace
       namespace: argocd
     spec:
@@ -126,16 +124,16 @@ spec:
         targetRevision: "folder_flows"
         path: charts/dev/capi-infra
         helm:
-          releaseName: '{{path.basename}}'
+          releaseName: "{{path.basename}}"
           valueFiles:
             # Bring in values that are specific to this application
-            - '../../../{{path}}/{{path.filename}}'
+            - "../../../{{path}}/{{path.filename}}"
             # Bring in secrets that are specific to this application
-            - 'secrets://../../../secrets/{{path[1]}}/{{path[2]}}/api-server-fip.yaml'
-            - 'secrets://../../../secrets/{{path[1]}}/{{path[2]}}/app-creds.yaml'
+            - "secrets://../../../secrets/{{path[1]}}/{{path[2]}}/api-server-fip.yaml"
+            - "secrets://../../../secrets/{{path[1]}}/{{path[2]}}/app-creds.yaml"
 
       syncPolicy:
-        preserveResourcesOnDeletion: false   
+        preserveResourcesOnDeletion: false
         automated:
           prune: true
           selfHeal: true

--- a/clusters/dev/management/apps.yaml
+++ b/clusters/dev/management/apps.yaml
@@ -52,8 +52,10 @@ spec:
             valuesFile: ../../../clusters/dev/management/argocd-setup-values.yaml
 
   syncPolicy:
+    # Don't remove everything if we remove the appset
     preserveResourcesOnDeletion: true
     automated:
+      # apps are easy to re-deploy, a git revert will bring it back
       prune: true
       selfHeal: true
       allowEmpty: true
@@ -77,9 +79,7 @@ spec:
         server: https://kubernetes.default.svc
         namespace: "{{namespace}}"
 
-      # apps are easy to deploy - so we can cascade delete them
       syncPolicy:
-        preserveResourcesOnDeletion: false
         automated:
           prune: true
           selfHeal: true
@@ -104,6 +104,7 @@ spec:
   syncPolicy:
     preserveResourcesOnDeletion: true
     automated:
+      # Infra requires more effort to re-deploy, so don't prune automatically
       prune: false
       selfHeal: true
       allowEmpty: true
@@ -133,8 +134,8 @@ spec:
             - "secrets://../../../secrets/{{path[1]}}/{{path[2]}}/app-creds.yaml"
 
       syncPolicy:
-        preserveResourcesOnDeletion: false
         automated:
+          # Remove anything that isn't in the helm chart output
           prune: true
           selfHeal: true
           allowEmpty: true


### PR DESCRIPTION
### Description:

The template is unable to preserve an application, since it's defined in
the applicationset instead of an application set creating N applications.
    
This means you can't add preserve to the template, since theres no way for Argo to actually do this

This should fix the auto-sync on dev failing to reconcile currently

### Special Notes:

- See second commit for human diff, the first is auto-formatting

---

### Submitter:

Have you:

* [ ] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
