### PR TITLE
DOC: Reformatting of documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,6 @@ This repo acts as the "central repository" of all configuration information for 
 
 We use ArgoCD to manage our clusters. Each cluster has its own argocd deployment that uses this repo as its source of truth
 
-# Quick Start
-
-These links assume you have existing clusters or applications to deploy within the repository. If you want to setup a cluster from scratch, you'll need to define a new cluster from the below links first:
-
-### Step-by-step-guides
-- [Deploying a new cluster](docs/clusters.md)
-- [Adding a new chart to this repo](docs/charts.md)
-- [Deploying a chart onto a cluster](docs/deploying-apps.md)
-
-
-### More information
-- [How it works - folder-based flow & promotion flowchart](docs/folder-based-flow.md)
-- [Deploying secrets](docs/secrets.md)  
-
-
 # Repository Structure
 
 This repository contains the following directories:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,28 @@
+# Deploying Apps using ArgoCD for STFC Cloud
+
+This documentation outlines how to set up clusters managed by ArgoCD in the STFC Cloud.
+
+## Quick Start
+
+### New to the ArgoCD folder workflow used? 
+
+**Start with:** [How it works - folder-based flow & promotion flowchart](folder-based-flow.md)
+
+
+### Deploying a New ArgoCD Environment?
+If you are starting from scratch and need to set up a new environment (e.g. deploying a new dev ArgoCD cluster), start with: [Deploying a new cluster](clusters.md)
+
+> [!INFO]
+> This guide assumes you already have a CAPI cluster already deployed to configure into a new ArgoCD environment.
+
+### Need to Deploy Secrets?
+Whether deploying from scratch or need to update secrets, see [Deploying Secrets](secrets.md)
+
+### Add a New Cluster to an Existing ArgoCD Environment?
+For new clusters being added to an existing environment to be managed through ArgoCD, see: [Deploying Child Clusters](child-clusters.md)
+
+### Adding a New Chart to this Repository?
+See [Adding a New Chart to This Repo](charts.md)
+
+### Deploying a Chart onto a Cluster?
+See [Deploying a Chart Onto a Cluster](deploying-apps.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ This documentation outlines how to set up clusters managed by ArgoCD in the STFC
 ### Deploying a New ArgoCD Environment?
 If you are starting from scratch and need to set up a new environment (e.g. deploying a new dev ArgoCD cluster), start with: [Deploying a new cluster](clusters.md)
 
-> [!INFO]
+> [!NOTE]
 > This guide assumes you already have a CAPI cluster already deployed to configure into a new ArgoCD environment.
 
 ### Need to Deploy Secrets?

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,3 +26,9 @@ See [Adding a New Chart to This Repo](charts.md)
 
 ### Deploying a Chart onto a Cluster?
 See [Deploying a Chart Onto a Cluster](deploying-apps.md)
+
+### Need to Set Up Longhorn App?
+See [App Setup Steps](app-setup.md)
+
+### Need to Set Up Specific Infra?
+See [Infra Setup Steps](infra-setup.md)

--- a/docs/app-setup.md
+++ b/docs/app-setup.md
@@ -2,15 +2,15 @@
 
 This section details some pre/post deployment steps for setting up specific apps
 
-# Longhorn
+## Longhorn
 
 Longhorn is a Cloud Native application for presistent block storage.  See [Longhorn docs](https://longhorn.io/docs/latest/).
 
 To deploy Longhorn we utilise the longhorn helm chart. See [Chart Repo](https://github.com/longhorn/longhorn/tree/master/chart).
 
-# Pre-deployment steps
+### Pre-deployment steps
 
-# 1. (Optional) Label nodes to run longhorn on
+#### 1. **(Optional)** Label nodes to run longhorn on
 
 Make sure you have labelled your nodes so that longhorn can use them as storage nodes. 
 
@@ -28,7 +28,9 @@ longhorn:
       longhorn.store.nodeselect/longhorn-storage-node: true	
 ```	
 
-**NOTE:** If you're NOT using `capi` - make sure you set these labels accordingly for your cluster. 	
+> [!WARNING]
+> If you are **NOT** using `capi` - make sure to set these labels accordingly for your cluster
+ 	
 
 If you want to change the node labels that capi uses - you can do so like this: 
 
@@ -40,20 +42,15 @@ openstack-cluster:
       longhorn.store.nodeselect/longhorn-storage-node: true
 ```	
 
-# 2. (Optional) Add tls secret 	
+#### 2. **(Optional)** Add TLS secret 	
 
+Longhorn is configured to use TLS by default, by default it uses a self-signed certificate.
 
-Longhorn is configured to use TLS by default, by default it uses a self-signed certificate which is not secure - recommended to get a proper certificate for production systems.	Longhorn is configured to use TLS by default, by default it uses a self-signed certificate which is not secure - recommended to get a proper certificate for production systems.
+> [!CAUTION]
+> For Production Systems, use a production certificate.
+> Do **NOT** use a self-signed certificate.
 
-
-Footer
-
-
-# 2. (Optional) Add tls secret 
-
-Longhorn is configured to use TLS by default, by default it uses a self-signed certificate which is not secure - recommended to get a proper certificate for production systems.
-
-you can create the tls secret like so:
+You can create the TLS secret like so:
 
 ```
 kubectl create secret tls longhorn-tls-keypair --key /path/to/privateKey.key --cert /path/to/certificate.crt -n longhorn-system
@@ -67,7 +64,7 @@ longhorn:
 ```
 
 
-# Post-deployement steps
+## Post-deployement steps
 
 Longhorn is already setup to be the default storageclass - if you're using CAPI you will need to drop csi-cinder storage class as being the default - you can do this by running
 
@@ -75,9 +72,9 @@ Longhorn is already setup to be the default storageclass - if you're using CAPI 
 kubectl patch storageclass csi-cinder -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
 ```
 
-# Common Problems 
+## Common Problems 
 
-## 1. Longhorn web UI is giving a 500 and ArgoCD is stuck processing
+### 1. Longhorn web UI is giving a 500 and ArgoCD is stuck processing
 
 Doing `kubectl get ds -n longhorn-system` shows a deployment with 0/0 instances
 

--- a/docs/child-clusters.md
+++ b/docs/child-clusters.md
@@ -1,12 +1,12 @@
 # Deploying a child cluster on an existing environment
 
 > [!NOTE]
-> The following documentation outlines how to deploy child clusters in an existing environment.
+> The following documentation outlines how to deploy child clusters in an **existing** environment.
 > See [Deploying a new environment](clusters.md) if deploying a new ArgoCD environment
 
 ## Prerequisites: 
-1. Create an application credential for your new cluster on your project
-2. Ensure enough quota for the cluster (RAM, CPU, instances etc)
+1. Create an application credential for the project the child cluster should be deployed in
+2. Ensure the project has enough quota for the cluster (RAM, CPU, instances etc)
 3. Provision a floating ip on your project for kubernetes API Server access
 4. (Optional) Provision a second floating IP for nginx ingress controller
 

--- a/docs/clusters.md
+++ b/docs/clusters.md
@@ -1,7 +1,7 @@
 # Deploying a new environment
 
 > [!NOTE]
-> The following documentation outlines how to deploy a **new** ArgoCD envrionment
+> The following documentation outlines how to deploy a **new** ArgoCD envrionment onto a `management` cluster.
 > See [Deploying a Child Cluster](child-clusters.md) if you are deploying a cluster using an existing environment.
 
 

--- a/docs/clusters.md
+++ b/docs/clusters.md
@@ -15,7 +15,7 @@
    - Ensure the name is `management` as CAPI cannot rename a cluster.
 
 
-| :exclamation:  Make sure you already have a CAPI cluster deployed before proceeding with rest of the documentation   |
+| :exclamation:  Make sure you already have a Kubernetes cluster deployed before proceeding with rest of the documentation   |
 |----------------------------------------------------------------------------------------------------------------------|
 
 

--- a/docs/clusters.md
+++ b/docs/clusters.md
@@ -1,7 +1,7 @@
 # Deploying a new environment
 
 > [!NOTE]
-> The following documentation outlines how to deploy a new ArgoCD envrionment
+> The following documentation outlines how to deploy a **new** ArgoCD envrionment
 > See [Deploying a Child Cluster](child-clusters.md) if you are deploying a cluster using an existing environment.
 
 
@@ -13,6 +13,11 @@
 5. Create a self-managed cluster called `management` 
    - see https://stfc.atlassian.net/wiki/spaces/CLOUDKB/pages/211878034/Cluster+API+Setup. 
    - Ensure the name is `management` as CAPI cannot rename a cluster.
+
+
+| :exclamation:  Make sure you already have a CAPI cluster deployed before proceeding with rest of the documentation   |
+|----------------------------------------------------------------------------------------------------------------------|
+
 
 ## Motivation
 You may want to make your own environment so you can test gitOps config or charts idependently of running clusters on test/feature branches
@@ -58,7 +63,10 @@ Repeat for all other clusters you want to add
 
 11. **(Optional)** If this is not a temporary environment - and you want to keep it around long term in `main` make a PR for it and get it merged
 
-12. Deploy age private key secret to management cluster - see [secrets](secrets.md) for more info
+12. Deploy age private key secret to management cluster
+
+**New to generating age keys and generating secrets?** See [secrets](secrets.md) for more information
+
 ``` cd scripts; ./deploy-helm-secret.sh <path-to-age-private-key>``` 
 
 13. Run deploy.sh on your self-managed cluster `management` like so:

--- a/docs/deploying-apps.md
+++ b/docs/deploying-apps.md
@@ -39,9 +39,6 @@ spec:
 
 ```
 
-> [!NOTE]
-> IGNORE THE EXISTING ELEMENTS
-
 `name`: name of ArgoCD-Application
 
 `chartName`: name of chart - matching directory name should be in `charts/<environment>/`

--- a/docs/deploying-apps.md
+++ b/docs/deploying-apps.md
@@ -1,13 +1,16 @@
-# Deploying a new app onto a cluster
+# Deploying a New App Onto a Cluster
 
 ## Prerequisites 
-To deploy a new app onto the cluster - make sure a chart exists for it. 
 
-A chart must be defined in `charts/<environment>/<chart-name>` 
-    - where `<environment>` is the environment of the cluster you want to deploy the app to
-    - see [charts](charts.md) for more info
+- Chart for the application
+  - This must be defined in `charts/<environment>/<chart-name>`, where `<environment>` is the environment of the cluster (e.g. dev/staging) you want to deploy the app to
+  - See [Charts](charts.md) for more information
 
-An Understanding of [ArgoCD Concepts](https://argo-cd.readthedocs.io/en/stable/core_concepts/), particularly [ApplicationSets](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/applicationset-specification/) 
+
+- Understanding of core ArgoCD Concepts: See [ArgoCD Concepts](https://argo-cd.readthedocs.io/en/stable/core_concepts/)
+  - In particular [ApplicationSets](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/applicationset-specification/) 
+
+To deploy a new app onto the cluster - make sure a chart exists for it.  
 
 ## Steps
 
@@ -36,7 +39,8 @@ spec:
 
 ```
 
-NOTE: IGNORE THE EXISTING ELEMENTS
+> [!NOTE]
+> IGNORE THE EXISTING ELEMENTS
 
 `name`: name of ArgoCD-Application
 
@@ -46,14 +50,16 @@ NOTE: IGNORE THE EXISTING ELEMENTS
 
     - NOTE: this `valuesFile` parameter is NON-OPTIONAL - you must provide a file, even if its blank
 
-NOTE: remember to encase any cluster-specific values for the chart in the sub-chart name to which they apply. E.g. for argo-cd values - they should be defined like: 
+> [!NOTE]
+> Remember to encase any cluster-specific values for the chart in the sub-chart name to which they apply. E.g. for argo-cd values - they should be defined like: 
+
 ```
 argo-cd:
    val1: foo
    val2: bar
 ```
 
-because `argo-cd` is the name of the subchart that installs argocd
+This is because `argo-cd` is the name of the subchart that installs argocd
 
 3. Commit and make a PR
 

--- a/docs/infra-setup.md
+++ b/docs/infra-setup.md
@@ -10,7 +10,7 @@ We utilise StackHPCs CAPI Chart to do this. See the docs [here](https://github.c
 
 ## Pre-deployment steps
 
-1. (Optional) Add TLS Certs - for CAPI Monitoring
+1. **(Optional)** Add TLS Certs - for CAPI Monitoring
 
 CAPI monitoring (which is enabled by default) requires TLS certs. 
 
@@ -29,7 +29,7 @@ kubectl create secret tls tls-keypair --cert certificate.crt --key privateKey.ke
 ```
 
 
-2. (optional) Enable sending monitoring alerts
+2. **(Optional)** Enable sending monitoring alerts
 
 Monitoring is enabled by default but will not send alerts out unless configured to. 
 In order to turn on alerts - edit the file `clusters/<environment>/<cluster-name>infra-values.yaml` and add the following
@@ -50,7 +50,7 @@ openstack-cluster:
 ```
 
 
-1. (optional) Change the ingress hostnames for monitoring endpoints
+3. **(Optional)** Change the ingress hostnames for monitoring endpoints
 
 ```
 openstack-cluster:
@@ -85,14 +85,16 @@ openstack-cluster:
                     secretName: tls-keypair
 ``` 
 
-**NOTE: make sure you follow the post-deployment steps too to configure sending emails**
+> [!NOTE]
+> Make sure to follow post-deployment steps below for configuring sending emails
+
 
 ## Post-deployment
 
-NOTE: this will likely be deprecated for using secrets
+> [!WARNING]
+> This will likely be deprecated for using secrets
 
-If you have enabled monitoring. 
-You need to manually set a few secrets that capi requires - this includes: 
+If you have enabled monitoring. You need to manually set a few secrets that capi requires - this includes: 
 
 1. The mail server to use to send alerts (If sending alerts)
 2. Which email address to send alerts to. (If sending alerts)
@@ -112,6 +114,6 @@ spec:
         value: <email-address>
 ```
 
-then you can run: 
+Then you can run: 
 `kubectl patch -n argocd app <cluster-name> --patch-file /tmp/capi_patch.yaml --type merge`
  


### PR DESCRIPTION
### Description:

Updates to some of the formatting and layout of documentation

---

### Submitter:

Have you:

* [ ] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
