### PR TITLE
Rotate the key on app-creds too

### DIFF
--- a/secrets/staging/management/app-creds.yaml
+++ b/secrets/staging/management/app-creds.yaml
@@ -19,20 +19,20 @@ sops:
         - recipient: age1hsll27prywydttq7dtnqtdnu2jpr8zhaulx00l7n4pqmxkhr55vspqmj6l
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPckZPQkV2b29xekdxL0g3
-            cEJwUk1OSmEwekcyWTVFOGVZaFBEWE15VlJBCkkvcXBWRDRYbUdndFVIYVVjdjJW
-            TDJaVzZCM3RGZ2d5ZjdMazBCVDQrSGsKLS0tIGlvRUYxQkwrdU9MZUxZOU5pY29q
-            QWRaMUFHdE5EcHlPRjRMcE05L25LeTQKD4DpUniIHpfLER9UHr9mKEzczkRhNuZ1
-            7hK6M34umym7nsISYSvYMM9NMg0YfZngTLX2zY8PXBeJjKfUssG2MQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOZUhCNmZJRWV1eXB0dkNQ
+            c1UrNkJJK2FNM0MzSGpVSzJtb3RWNy85WjFJCnlHZ1ZBMjEyMVlUc0dMdHNsRExZ
+            bFVMMWczbm5yYStRMWNFNW9rSlJ4NWcKLS0tIFdhT2xwTk5hQnlTbGRPRGJwMnZW
+            VFVZQ3k4ZEhYVVB5WUtEVVoycExjS3MKVkRpwNVLHrdQEU50FS4KeCs/CKv5ppJC
+            EkcsDu9lV44Zv3m6PgZI5lM3p0iJLR0tcQsshpXzNaHT74a6iVVo3w==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1cx49ss4m25nzm8ju80g2jmpwdj72fvyllzqj6nh3lx3jdmgqnfss80z4xs
+        - recipient: age1p9rynn6rcdfhx0kdks0sh5drjrjg857cuujapu04m9a2r0zarq6stdha6c
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGcHI3bndTQjZucUEyOSs5
-            em05d2VZcnRoTUdBRHN1aU04L29jZGJtMWpjCllwcTVydGRBb2IrZUVuUnZhbktE
-            dnhNbUlObUxDVjd6UXJYTUxRR3VYbEkKLS0tIEpIRHM1ZjJRT3ZXVnI0dVVqeVdN
-            N1d6L29qeWJBZW1qMlhiRS9sK1BQdm8KHJxX2aXETv5HUsQpbnGZvq+/dX7Sn+vA
-            lxOpfkb9Ag1uEh0WtfZYOfZfHaEygeqvZaI9QX3jcwBcaXb09soGGg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvTld6VVVRNVd3aWpjK1o3
+            MWlxRThUY2wycVE1VXprcWJXOW5teEdrNEJBCjVDV3BOaVQzM0Z4eVc4UEN2MWJV
+            QldtaTFJT1U0MlhDOGN6T05GMFQrWFUKLS0tIHVkNE1HZnVaWk03UTlkZkphdVhv
+            N0d2QU9BU2pPd0JjT25PNjd1bGZVSlEKO1yBeypB8a34Q7S3ppawVYIO8/D/S02d
+            MFW59WkB09g9eGlMdmKdL6l4I8na7njBuXuK6gFt4AghbvmdrcSTcA==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2024-07-01T11:06:06Z"
     mac: ENC[AES256_GCM,data:RJi8iwcCflsw6YcohOuZy/+PEenecYm3ywrK1quK0+d2cSp25pTb/O4ZSJjCz54jSBU6HGenMMH+AaBd2+mCTQ6oXVovBjAyZ7gjd+e04wgJGFunfn6oN+5tXkc5ebWjYdpJnZR0bOIxEWRS3oEizoUAsTJtSbBc51YIdYOV0lA=,iv:EGu+13ih+iPj65ER8/Ob7Qwq6xZdULmSLzaxZrjd6Pk=,tag:d0IRxZToQc1MRZW4xbV9IA==,type:str]


### PR DESCRIPTION
### Description:

The previous commit updated the app cred secret, but did not rotate the public key for the app creds. This is preventing us from actually deploying.

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- If this is a hotfix for production, which needs to be deployed after merging
- If this requires manual work to deploy the PR, e.g. a parameter change
- If this has associated internal documentation too
-->

---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
