### PR TITLE
BUG: Use app name implicitly

### DIFF
--- a/clusters/staging/management/apps.yaml
+++ b/clusters/staging/management/apps.yaml
@@ -111,7 +111,6 @@ spec:
         targetRevision: main
         path: charts/staging/capi-infra
         helm:
-          releaseName: "{{path.basename}}"
           valueFiles:
             # Bring in values that are specific to this application
             - "../../../{{path}}/{{path.filename}}"


### PR DESCRIPTION
### Description:

Use the app name implicitly, rather than explicitly saying the name again for the helm release: https://argo-cd.readthedocs.io/en/stable/user-guide/helm/#helm-release-name
This ensures that the cluster name matches the user's expectation when it's installed

<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- If this is a hotfix for production, which needs to be deployed after merging
- If this requires manual work to deploy the PR, e.g. a parameter change
- If this has associated internal documentation too
-->

---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
