### PR TITLE
bump capi-helm-chart version on dev chart

### DIFF
--- a/charts/dev/openstack-cluster/requirements.yaml
+++ b/charts/dev/openstack-cluster/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - repository: https://stackhpc.github.io/capi-helm-charts
     name: openstack-cluster
-    version: 0.6.0
+    version: 0.9.0


### PR DESCRIPTION
bump from 0.6.0 to 0.9.0
