### PR TITLE
BUG: rotate worker sops key

### DIFF
--- a/secrets/dev/worker/.sops.yaml
+++ b/secrets/dev/worker/.sops.yaml
@@ -8,7 +8,7 @@ creation_rules:
           # David Fairbrother Laptop
           - age1h3dmygqf4v6jg3nxk5sr9jkp27w3q83sqnqxdd5n92xf3w6fs5kshakrxn
           # Temp Dev Argo Key
-          - age1x0t4j6qxqy42usha0u658r4f5p5d48y8knfuchyu2sc2rywtacgsryp0t6
+          - age1xr298hh8ammzethfcdeh72c25wnrk3u2zlzxx78k4nfcq2rwpgqs9hljq8
           # Anish Mudaraddi
           - age12khufkd7z25eqgpjjyy0zcrq6kpjxzekmff5zhq7q54tajm4e58qul35x0
           # Ramzi Jalili


### PR DESCRIPTION
this should be the same as management argo key because management needs to decrypt these secrets as it is responsible for building all worker clusters
