### PR TITLE
change back capi-addons version to 0.5.9

### DIFF
--- a/charts/dev/cluster-api-addon-provider/requirements.yaml
+++ b/charts/dev/cluster-api-addon-provider/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - repository: https://azimuth-cloud.github.io/cluster-api-addon-provider
     name: cluster-api-addon-provider
-    version: 0.6.0
+    version: 0.5.9


### PR DESCRIPTION
release 0.6.0 hasn't yet been released to chart repo
