### PR TITLE
BUG: install crds for cert-manager

### DIFF
--- a/charts/staging/cert-manager/values.yaml
+++ b/charts/staging/cert-manager/values.yaml
@@ -9,4 +9,5 @@ cert-manager:
   le-prod:
     enabled: false
 
-  installCRDs: true
+  crds:
+    enabled: true


### PR DESCRIPTION
this doesn't work for child clusters - the values were misconfigured
