### PR TITLE
hotfix - revert galaxy cluster image to 1.28.7

### DIFF
--- a/clusters/dev/galaxy/infra-values.yaml
+++ b/clusters/dev/galaxy/infra-values.yaml
@@ -1,4 +1,7 @@
 openstack-cluster:
+  kubernetesVersion: "1.28.7"
+  machineImage: "capi-ubuntu-2004-kube-v1.28.7-2024-03-01"
+
   controlPlane:
     machineCount: 3
 


### PR DESCRIPTION
this is running on prod openstack so we don't have the new image available
