### PR TITLE
MAINT: setup smtp smarthost secret for dev

### DIFF
--- a/clusters/dev/management/apps.yaml
+++ b/clusters/dev/management/apps.yaml
@@ -117,6 +117,7 @@ spec:
             # Bring in secrets that are specific to this application
             - "secrets://../../../secrets/{{path[1]}}/{{path[2]}}/api-server-fip.yaml"
             - "secrets://../../../secrets/{{path[1]}}/{{path[2]}}/app-creds.yaml"
+            - "secrets://../../../secrets/{{path[1]}}/smtp-smarthost.yaml"
 
       syncPolicy:
         automated:

--- a/secrets/dev/.sops.yaml
+++ b/secrets/dev/.sops.yaml
@@ -1,0 +1,8 @@
+creation_rules:
+  - unencrypted_regex: "^(apiVersion|metadata|kind|type)$"
+    key_groups:
+      - age:
+          # Temp Dev Argo Key
+          - age1xr298hh8ammzethfcdeh72c25wnrk3u2zlzxx78k4nfcq2rwpgqs9hljq8
+          # Anish Mudaraddi
+          - age12khufkd7z25eqgpjjyy0zcrq6kpjxzekmff5zhq7q54tajm4e58qul35x0

--- a/secrets/dev/smtp-smarthost.yaml
+++ b/secrets/dev/smtp-smarthost.yaml
@@ -1,0 +1,41 @@
+openstack-cluster:
+    addons:
+        monitoring:
+            kubePrometheusStack:
+                release:
+                    values:
+                        alertmanager:
+                            config:
+                                global:
+                                    #ENC[AES256_GCM,data:RKkzJKO5A1vdJ785UpuYQEMT8ArJVDlzq9P8lif9PSxNGEKXQw==,iv:X0k9SBfcXppduvBnOlyXZwcNT1NzrcegK+6TdSwbTDs=,tag:Pm19NDKVUCOIcr4QFZePgQ==,type:comment]
+                                    #ENC[AES256_GCM,data:FQbJPFCKDxie7UT6NBLZhKoBgLKiiKv+NT3ehC/DtMYqtCX6JGqo,iv:D1RRESz6D6L4mb8908B936mY7hii0w2iv2SLAfIcQfw=,tag:Vdv6o+eay3hq9iIGf3nmEQ==,type:comment]
+                                    smtp_smarthost: null
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1xr298hh8ammzethfcdeh72c25wnrk3u2zlzxx78k4nfcq2rwpgqs9hljq8
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwVHlzRkgyN3JSVEZ6VkVx
+            V3lHQkM3b21rVEowVmFyVElxQWZ2T1pId1NRCmhmeVlwRERNeFFDdmYzZzRWM2Rs
+            RkdZTk9Fb3R3REt2SGllZXAzWlpFYjQKLS0tIFcvV3RMMW1pOEM2TS80elZDSlFr
+            MjhZTVBJVmR3WVNHRWhqV1RGdTlTcU0KkZLfxliBhQ41GkA8HFCI7/zzV+6UQtot
+            t6DH7zR0uoNLXfgXidX7kR+SU6bY/eJa+CR3ntlDc/PH8WKNmfsoOw==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age12khufkd7z25eqgpjjyy0zcrq6kpjxzekmff5zhq7q54tajm4e58qul35x0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxYXlHOXRZR1ZwVGFxK0VF
+            UUJESjRmS1NwVU5KR3JhVGVMcUp2b1Y4Snp3CkNJK2ZYVmRkY0RiVEVsdzA5SGRs
+            OWllY0xsVVF4OFRrai9lbzl4NHBMRzAKLS0tIENjUnc0MmlBTUZJOTgwK2hlbDI3
+            c0l2N2NVd3lCQlFZb3Z1c2hLcENJM0UKPTfDwVjH4yvoctLWcqcGdHGaffthFEtr
+            b1AUpC1PJ8lfq5ABDdxgPNqrQNt6QPf+/QywAo04rZjW0ssE2nG7qQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2024-09-11T09:07:36Z"
+    mac: ENC[AES256_GCM,data:D+TnMa71YrVlIodFstkTIQdnoZDdCAa7Nw4S8AR1z10p2s/HscnRLMvNyE6qJ12cPx6J+MonHtTybh+6nR1wd/cKrU2XqpaNDOMgF8uPIPWXsIcXndWCPoFSSbU6+u0dwlDAutvT9SakxDXKURViQfPLNBkisPSINTXpHkHNiTs=,iv:nJwq1+fMMKI8OpSIinhPOX2PY0HSP8jjOsbAvJw6fKU=,tag:mwc2GjL8t7PFqBdqLS3UsA==,type:str]
+    pgp: []
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.8.1


### PR DESCRIPTION
this will set the smtp smarthost endpoint as a secret for dev - this is empty because we don't want to send alerts for dev - but makes it easier to promote changes to staging and prod
