### PR TITLE
BUG: make dev capi-infra values consistent with staging

### DIFF
--- a/charts/dev/capi-infra/values.yaml
+++ b/charts/dev/capi-infra/values.yaml
@@ -230,7 +230,7 @@ openstack-cluster:
                 - name: 'null'
                 - name: default-receiver
                   email_configs:
-                  - to:
+                  - to: cloud-support@stfc.ac.uk
                     send_resolved: true
                     headers:
                       subject: |
@@ -268,13 +268,6 @@ openstack-cluster:
 
                 templates:
                   - '/etc/alertmanager/config/*.tmpl'
-
-              alertmanagerSpec:
-                # turn off persistent storage so cinder volume doesn't get created
-                # TODO: remove this when cinder creation issue resolved on dev         
-                storage: 
-                  emptyDir: 
-                    medium: Memory
 
             grafana:
               enabled: true


### PR DESCRIPTION
dev capi-infra values previously were set to not use cinder volumes because they were broken - this should have been put into cluster-specific values rather than the shared chart values - this PR fixes that

In addition, I forgot to specify to use cloud-support email for sending alerts
