### PR TITLE
ENH: Add alerting to dev management

### DIFF
--- a/clusters/dev/management/infra-values.yaml
+++ b/clusters/dev/management/infra-values.yaml
@@ -42,3 +42,18 @@ openstack-cluster:
                   - hosts:
                       - grafana-mgmt.dev.nubes.stfc.ac.uk
                     secretName: tls-keypair
+            alertmanager:
+              enabled: true
+              ingress:
+                hosts:
+                  - alertmanager-mgmt.dev.nubes.stfc.ac.uk
+                tls:
+                  - hosts:
+                      - alertmanager-mgmt.dev.nubes.stfc.ac.uk
+                    secretName: tls-keypair
+              alertmanagerSpec:
+                # turn off persistent storage so cinder volume doesn't get created
+                # TODO: remove this when cinder creation issue resolved on dev
+                storage:
+                  emptyDir:
+                    medium: Memory


### PR DESCRIPTION
this is the only dev cluster we should add alerting to - just to ensure that we can create new clusters for development work
