### PR TITLE
BUG: make capi-infra chart consistent

### DIFF
--- a/charts/dev/capi-infra/values.yaml
+++ b/charts/dev/capi-infra/values.yaml
@@ -310,13 +310,6 @@ openstack-cluster:
                   - hosts: 
                     - "prometheus.example.com"
                     secretName: tls-keypair
-              
-              prometheusSpec:
-                # turn off persistent storage so cinder volume doesn't get created
-                # need to debug cinder volume creation issue on dev
-                storageSpec: 
-                  emptyDir: 
-                    medium: Memory    
     ingress:
       enabled: false
     

--- a/charts/staging/capi-infra/values.yaml
+++ b/charts/staging/capi-infra/values.yaml
@@ -310,13 +310,6 @@ openstack-cluster:
                   - hosts: 
                     - "prometheus.example.com"
                     secretName: tls-keypair
-              
-              prometheusSpec:
-                # turn off persistent storage so cinder volume doesn't get created
-                # need to debug cinder volume creation issue on dev
-                storageSpec: 
-                  emptyDir: 
-                    medium: Memory    
     ingress:
       enabled: false
     


### PR DESCRIPTION
I thought we removed prometheusSpec (dev specific value) from capi-infra charts but apparently not 

