### PR TITLE
BUG: rule labels don't get applied to every prometheus alert

### DIFF
--- a/charts/dev/capi-infra/values.yaml
+++ b/charts/dev/capi-infra/values.yaml
@@ -159,7 +159,7 @@ openstack-cluster:
         release:
           values:
             defaultRules:
-              additionalRuleLabels:
+              labels:
                 # these values used for alerting only - part of the email subject tag-line
                 cluster: not-set
                 env: dev

--- a/clusters/dev/galaxy/infra-values.yaml
+++ b/clusters/dev/galaxy/infra-values.yaml
@@ -31,8 +31,8 @@ openstack-cluster:
         release:
           values:
             defaultRules:
-              additionalRuleLabels:
-                cluster: dev-galaxy
+              labels:
+                cluster: galaxy
                 env: dev
             alertmanager:
               enabled: false

--- a/clusters/dev/management/infra-values.yaml
+++ b/clusters/dev/management/infra-values.yaml
@@ -24,8 +24,9 @@ openstack-cluster:
         release:
           values:
             defaultRules:
-              additionalRuleLabels:
-                cluster: dev-management
+              labels:
+                cluster: management
+                env: dev
             prometheus:
               ingress:
                 hosts:

--- a/clusters/dev/worker/infra-values.yaml
+++ b/clusters/dev/worker/infra-values.yaml
@@ -30,8 +30,9 @@ openstack-cluster:
         release:
           values:
             defaultRules:
-              additionalRuleLabels:
-                cluster: dev-worker
+              labels:
+                cluster: worker
+                env: dev
             prometheus:
               ingress:
                 hosts:


### PR DESCRIPTION
An attempt to fix an issue where labels don't get applied to every alert leaving the alert having blank values for env and cluster which leads to confusing alert messages
