### PR TITLE
BUG: set external rule labels

### DIFF
--- a/charts/dev/capi-infra/values.yaml
+++ b/charts/dev/capi-infra/values.yaml
@@ -158,12 +158,6 @@ openstack-cluster:
       kubePrometheusStack:
         release:
           values:
-            defaultRules:
-              labels:
-                # these values used for alerting only - part of the email subject tag-line
-                cluster: not-set
-                env: dev
-            
             alertmanager:
               enabled: false
               service:
@@ -293,7 +287,11 @@ openstack-cluster:
 
             prometheus:
               enabled: true
-
+              prometheusSpec:
+                externalLabels:
+                  cluster: not-set
+                  env: dev
+                       
               service:
                 type: ClusterIP
 

--- a/clusters/dev/galaxy/infra-values.yaml
+++ b/clusters/dev/galaxy/infra-values.yaml
@@ -30,10 +30,6 @@ openstack-cluster:
       kubePrometheusStack:
         release:
           values:
-            defaultRules:
-              labels:
-                cluster: galaxy
-                env: dev
             alertmanager:
               enabled: false
               ingress:
@@ -44,6 +40,10 @@ openstack-cluster:
                       - alertmanager-galaxy.dev.nubes.stfc.ac.uk
                     secretName: tls-keypair
             prometheus:
+              prometheusSpec:
+                externalLabels:
+                  cluster: galaxy
+                  env: dev
               ingress:
                 hosts:
                   - prometheus-galaxy.dev.nubes.stfc.ac.uk

--- a/clusters/dev/management/infra-values.yaml
+++ b/clusters/dev/management/infra-values.yaml
@@ -23,11 +23,11 @@ openstack-cluster:
       kubePrometheusStack:
         release:
           values:
-            defaultRules:
-              labels:
-                cluster: management
-                env: dev
             prometheus:
+              prometheusSpec:
+                externalLabels:
+                  cluster: management
+                  env: dev
               ingress:
                 hosts:
                   - prometheus-mgmt.dev.nubes.stfc.ac.uk

--- a/clusters/dev/worker/infra-values.yaml
+++ b/clusters/dev/worker/infra-values.yaml
@@ -29,11 +29,11 @@ openstack-cluster:
       kubePrometheusStack:
         release:
           values:
-            defaultRules:
-              labels:
-                cluster: worker
-                env: dev
             prometheus:
+              prometheusSpec:
+                externalLabels:
+                  cluster: worker
+                  env: dev
               ingress:
                 hosts:
                   - prometheus-worker.dev.nubes.stfc.ac.uk


### PR DESCRIPTION
related to #161 - that fix doesn't work 

Instead we'll try using external rule labels for prometheus to bypass the need to set label for each rule individually - this circumvents the issue found in azimuth-cloud capi-helm charts where they hardcode creating prometheus rules without a way for us to add in these labels - https://github.com/azimuth-cloud/capi-helm-charts/blob/4207923e8167fce27a5b96712cd164be3a5023d5/charts/cluster-addons/templates/ingress-nginx.yaml#L89-L121

More on externalrules can be found here - https://support.tools/use-external-labels-prometheus-alerts/