### PR TITLE
Move vicdev cluster back to dev

### DIFF
--- a/clusters/dev/vicmet/infra-values.yaml
+++ b/clusters/dev/vicmet/infra-values.yaml
@@ -24,5 +24,5 @@ openstack-cluster:
             controller:
               service:
                 # create a floatip for ingress on your project and put it here
-                loadBalancerIP: "130.246.81.220" 
+                loadBalancerIP: "130.246.211.115" 
 

--- a/secrets/dev/vicmet/api-server-fip.yaml
+++ b/secrets/dev/vicmet/api-server-fip.yaml
@@ -1,7 +1,7 @@
 openstack-cluster:
     apiServer:
         #ENC[AES256_GCM,data:iXJE8x4XJRQK0JJnTPl4+U6QV4M+DWLyn7lnfnzowE1U2pj55b6hqdZ5VMScEAkPaAaUA//4N5gFA4StkhNLPQ==,iv:iRSkNlw3xso/YoXd2uAaSHVDPf0iZBhzcdi2xjDv2xw=,tag:JDvzMflzzSqTXhn8G6YXDA==,type:comment]
-        floatingIP: ENC[AES256_GCM,data:OU8R/r3fC9aDTPhQq7g=,iv:p5zFTFUgHomLFNYaQkKF0gJ686EWUvQtYRjPr9ffBr4=,tag:D7A97Hcq6N44fkUC9ZjK5g==,type:str]
+        floatingIP: ENC[AES256_GCM,data:8RztDxkqRhHmzT/N3G/C,iv:GY4RZvkRiF39vfLFVpxz15WQT/j+7Gj9jTAiDrgZKeI=,tag:wY9mG99m6m55ZEEk2CP0tg==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -53,8 +53,8 @@ sops:
             Z0pVZGMwNkR0N2tjUTJycEFLVml5ZVUKRXbWCym3gL4Tq/fqNGe5mtdHjE1CigOa
             7ETrpfmO9M8gKgg+tIbwoanzdYBrqQfC0VpPubIW3/UMF7CxGHvrHw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-10-02T14:21:25Z"
-    mac: ENC[AES256_GCM,data:HWv6FmHSCOHxc0YUu0/t1MUZSIra6BarmqwDwqBGdXuOgHlaKY0xNtbcwgMgYtY0qxR+n9wOechbO124e2CrT9jll6LsFU50z9Lx7zBCLcmrc7/sHggPG/deMVj7orKceDoBWjYI2ymCzyrX2/BfV9uAdjqQLRmYNODPeTP8dsU=,iv:ZsTvHrMyRgYtxKIcLTqE6QXPLiHc9X9txeDd+htpGRQ=,tag:8zKZXlLk6Jqc+78ItqZ2nw==,type:str]
+    lastmodified: "2024-10-03T07:27:57Z"
+    mac: ENC[AES256_GCM,data:nKvZqPKOvUrxxKIbkinWlk/uEqX3nQWE9xN4kMeaIPP5ywHUTDXELzublnguo4fkBpjXY2JNuDaCzV0c7dR25hHijKwu9GEGeDZCoOHy459sc10Fwi8GIqgUeCp6MzVUV7lUOBxyn6Lhn0DipHT5TdQbcOCHNlLGSnGv9r9o36A=,iv:4He6RWflhVvvRhPXaUHnHmrdg/Tfo+tbuimnxKY6I3A=,tag:6riF8OJ0eSWtSPcyrjLsbw==,type:str]
     pgp: []
     unencrypted_regex: ^(apiVersion|metadata|kind|type)$
     version: 3.9.0

--- a/secrets/dev/vicmet/app-creds.yaml
+++ b/secrets/dev/vicmet/app-creds.yaml
@@ -2,10 +2,10 @@ openstack-cluster:
     clouds:
         openstack:
             auth:
-                auth_url: ENC[AES256_GCM,data:pQ6MjPQqUexYYEvTBezBoRD+d2yxXIhtFgvV6S04srBG,iv:U88zNw8Qyom6X7SSE3qh1kH9Shgu2gFb8lQoG3rK1AA=,tag:EeQPolgXI7Z44b66YPEJgQ==,type:str]
-                project_id: ENC[AES256_GCM,data:DCZMpLESVx0q7aywi0+xVI1QmcS64xHC0VqSWjvtCSg=,iv:qwU7tW8eOVcthzkVSPjGYURxA8MvQdJIoBO8dpAQ3eA=,tag:juilEuRVUYhJWi9hdzJn3w==,type:str]
-                application_credential_id: ENC[AES256_GCM,data:ywFIZNn5azADSztI6pCBCVA/35hmJnpN2aEzXnDCu/U=,iv:XRV278v/i7M+YIjMvpvaxeJvsXrSijJ1imBUSTcXHBU=,tag:Xu9ahQTA6l51rZSANqYD0A==,type:str]
-                application_credential_secret: ENC[AES256_GCM,data:RMjBJyGyZ4ujXa4JslyuC2wEANlW5kp9gY3xm3fluPeE+xNWWc6LczNBCv+gEyoIMkjM8D4XCgBi59qnzBTQhwtpdmfOo+x+Fgt8FnaVB3830hmiIMc=,iv:qrgQCojgrhe1ILvw8KmcZQuNZCgnQ7ysrdKOns4G6Fk=,tag:eusZxZp/AkGRp46IPm7FGg==,type:str]
+                auth_url: ENC[AES256_GCM,data:1cz+ou9SwjQOJrhGVK11YfXgvIHxYy40mZkuKrQ4NmgRHvpiFA==,iv:u4pZAcBUk4GU4y2EyLzeVIjMu390OKigcWfAkUm5ylg=,tag:cgEhMqQf3sImKtZ/3cOeWA==,type:str]
+                project_id: ENC[AES256_GCM,data:Yqtwhq6BqH3Yo5o0KiXzIFAyYYbS91OKUTLH52d2LPE=,iv:e/17q9eHu6nYx8jCYdR0n/fGUxSqc1/DdxW7Omc3aAU=,tag:/SM7Xc/F9pwQZrG6mCBCKw==,type:str]
+                application_credential_id: ENC[AES256_GCM,data:GQQ1xtcSZhf5k7EqSZ/hEGdm+O/lbBtVdM9oXEpZHLQ=,iv:aPy1IM5JYOVIAEyKHLe5GatrFhIuB0icVhO+HfLHt1E=,tag:LMeeB7WTJr+HCZhTIqecNA==,type:str]
+                application_credential_secret: ENC[AES256_GCM,data:XBuIztdPV4ptW0Q5pR4+Tkq8Jt7y8pITMFaB4iYLICBsmb+754XQEvOrBwpqrJmhD0/zCGxdO6ZAWn0NnjZKRDEfYI/N3OWw5OcANOs2w+5BGgQGOEg=,iv:FdyVfJbX/NRHuJtjHy96MXFLmwL5KpzD+JanzfdPlno=,tag:nQgTHJQs78fC//2sM91NMQ==,type:str]
             region_name: ENC[AES256_GCM,data:ONV21PkFYtt0,iv:+dkrfN/vbyB23Jq/QeHn3J3GKKz+SVCkB7qTL5DzMYs=,tag:JN8zNjU+tzBlApf183waTg==,type:str]
             interface: ENC[AES256_GCM,data:cJmm9FQH,iv:kZe1HmGyDL8dDnp2Lb4CmMtZ6rP9qDuH1c6IEJJNaUM=,tag:UrUPO2bKUxFqmBXZ6eYN4A==,type:str]
             identity_api_version: ENC[AES256_GCM,data:lg==,iv:SNY7aGRNUi4zGSK9jkosivapOC7h81S9e1bVliddfkY=,tag:I1IW9QvNGFRALY45qe9Wrw==,type:int]
@@ -61,8 +61,8 @@ sops:
             S215c0dIN1MxZHRiZ093T1FEdkpmSHMKOPqGPfL3lqjn8dDcwWqzOL1+VLTVmbce
             hAv0PVVvoBnizwGPM9obgqAZpvnDYI+jEkmMmVMQl7NfVKpfHk5k4Q==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-10-02T14:16:03Z"
-    mac: ENC[AES256_GCM,data:fuyeCINGD1oDGVCZI0jCFkXLLKjNZXEg+428bSJYXv9DHElAx1hhOX1yIVt+IFD3s8fmyPUT9C0Rxfu5M8suMoOsQG0p2mLqWcbj9oWoDZukpT6uu8SGzKhV6mzJwKclZGI83p5u6M3cUDPP0xuDHkeMGGrhCk73fjGGokvJ6iY=,iv:8yN6WuqShu/nMhpdidCl0eFIExrCefLZpbdAG1gqH8A=,tag:ZX0a8ak4GujSpG3FVxf6vw==,type:str]
+    lastmodified: "2024-10-03T07:20:42Z"
+    mac: ENC[AES256_GCM,data:fBgAu2cQrfDcL8LfWlPlXacLj3yDZTLCy+9TaxLuto/4d0t30XLxXjAW/jBqwW2+OXPTzNZFujVfo5Xlr3o8kfjS7x4tVNHoex6vjpejn2y30AJNbBT0K4RMEluSUXmYd8AxRBa1NrHuHYLqO9BtX5nN3W5My6uOQpqCRky5vtY=,iv:1fkCwoR865oE/YlXkwJfJL39ouw+2idFA7TuPsQagME=,tag:i/NORuXY3GvghwlpNWsWVw==,type:str]
     pgp: []
     unencrypted_regex: ^(apiVersion|metadata|kind|type)$
     version: 3.9.0


### PR DESCRIPTION
### Description:

Change app-creds and FIPs back to dev 

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- If this is a hotfix for production, which needs to be deployed after merging
- If this requires manual work to deploy the PR, e.g. a parameter change
- If this has associated internal documentation too
-->

---

### Submitter:

Have you:

* [ ] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
