### PR TITLE
Update deploy.sh

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -34,7 +34,7 @@ fi
 
 # Installing dependencies for cert-manager (temp fix)
 helm repo add jetstack https://charts.jetstack.io --force-update
-helm install cert-manager jetstack/cert-manager   --namespace cert-manager   --create-namespace   --version v1.15.3   --set crds.enabled=true
+helm install cert-manager jetstack/cert-manager   --namespace cert-manager   --create-namespace  --set crds.enabled=true
 
 helm dependencies update "../charts/$ENVIRONMENT/argocd"
 helm upgrade --install argocd "../charts/$ENVIRONMENT/argocd" \

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -32,6 +32,10 @@ if ! kubectl get secret helm-secrets-private-keys -n argocd &> /dev/null; then
     kubectl create secret generic helm-secrets-private-keys -n argocd
 fi
 
+# Installing dependencies for cert-manager (temp fix)
+helm repo add jetstack https://charts.jetstack.io --force-update
+helm install cert-manager jetstack/cert-manager   --namespace cert-manager   --create-namespace   --version v1.15.3   --set crds.enabled=true
+
 helm dependencies update "../charts/$ENVIRONMENT/argocd"
 helm upgrade --install argocd "../charts/$ENVIRONMENT/argocd" \
   -f "../clusters/$ENVIRONMENT/$CLUSTER_NAME/argocd-setup-values.yaml" \


### PR DESCRIPTION
Add a temp fix to get cert-manager crds

### Description:

Added two lines to deploy.sh to get a repo and install CRDs for cert-manager

---

### Submitter:

Have you:

* [ ] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
