### PR TITLE
BUG: use older image for dev worker

### DIFF
--- a/clusters/dev/worker/infra-values.yaml
+++ b/clusters/dev/worker/infra-values.yaml
@@ -1,6 +1,4 @@
 openstack-cluster:
-  kubernetesVersion: "1.28.12"
-  machineImage: "capi-ubuntu-2004-kube-v1.28.12-2024-08-22"
 
   controlPlane:
     machineCount: 3


### PR DESCRIPTION
This image is not usable due until new version of capi helm charts is released
