### PR TITLE
MAINT: remove group requirement for galaxy iris-iam login

### DIFF
--- a/clusters/dev/galaxy/materials-galaxy-values.yaml
+++ b/clusters/dev/galaxy/materials-galaxy-values.yaml
@@ -1,7 +1,7 @@
 oauth2-proxy:
   extraArgs:
     # limit access to stfc-cloud-dev group
-    allowed-group: "stfc-cloud-dev"
+    # allowed-group: "stfc-cloud-dev"
     redirect-url: "https://galaxy.dev.nubes.stfc.ac.uk/oauth2/callback"
 
 galaxy:


### PR DESCRIPTION
needed so PSDI can test this without adding them to stfc-cloud-dev group
