### PR TITLE
MAINT: promoting dev capi-infra monitoring changes

### DIFF
--- a/charts/staging/capi-infra/Chart.yaml
+++ b/charts/staging/capi-infra/Chart.yaml
@@ -1,3 +1,7 @@
 apiVersion: v2
 name: capi-openstack-cluster
 version: 1.0.0
+dependencies:
+  - repository: https://azimuth-cloud.github.io/capi-helm-charts
+    name: openstack-cluster
+    version: 0.10.1

--- a/charts/staging/capi-infra/requirements.yaml
+++ b/charts/staging/capi-infra/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-  - repository: https://azimuth-cloud.github.io/capi-helm-charts
-    name: openstack-cluster
-    version: 0.10.1

--- a/charts/staging/capi-infra/values.yaml
+++ b/charts/staging/capi-infra/values.yaml
@@ -158,12 +158,6 @@ openstack-cluster:
       kubePrometheusStack:
         release:
           values:
-            defaultRules:
-              additionalRuleLabels:
-                # these values used for alerting only - part of the email subject tag-line
-                cluster: not-set
-                env: dev
-            
             alertmanager:
               enabled: false
               service:
@@ -233,9 +227,9 @@ openstack-cluster:
                   - to: cloud-support@stfc.ac.uk
                     send_resolved: true
                     headers:
-                      subject: |
+                      subject: | 
                         {%- raw %}
-                        "({{ .CommonLabels.env }} : {{ .CommonLabels.cluster }}) {{ .Status | toUpper }} {{ .CommonLabels.alertname }}"
+                        "({{ .CommonLabels.env }} : {{ .CommonLabels.cluster }} : {{ .CommonLabels.service | default "Multiple Services" }}) {{ .Status | toUpper }} {{ .CommonLabels.alertname | default "Multiple Alerts" }}"
                         {%- endraw %}
                     html: |-
                       {%- raw %}
@@ -293,6 +287,10 @@ openstack-cluster:
 
             prometheus:
               enabled: true
+              prometheusSpec:
+                externalLabels:
+                  cluster: not-set
+                  env: dev
 
               service:
                 type: ClusterIP

--- a/clusters/staging/management/infra-values.yaml
+++ b/clusters/staging/management/infra-values.yaml
@@ -23,10 +23,11 @@ openstack-cluster:
       kubePrometheusStack:
         release:
           values:
-            defaultRules:
-              additionalRuleLabels:
-                cluster: staging-management
             prometheus:
+              prometheusSpec:
+                externalLabels:
+                  cluster: management
+                  env: staging
               ingress:
                 hosts:
                   - prometheus-mgmt.staging.nubes.stfc.ac.uk

--- a/clusters/staging/worker/infra-values.yaml
+++ b/clusters/staging/worker/infra-values.yaml
@@ -13,10 +13,11 @@ openstack-cluster:
       kubePrometheusStack:
         release:
           values:
-            defaultRules:
-              additionalRuleLabels:
-                cluster: staging-worker
             prometheus:
+              prometheusSpec:
+                externalLabels:
+                  cluster: worker
+                  env: staging
               ingress:
                 hosts:
                   - prometheus-worker.staging.nubes.stfc.ac.uk


### PR DESCRIPTION
### Description:
dev capi-infra chart copied to staging - changes made to cluster infra-values.yaml to match dev. This has been running on dev for a week or so

This will make our alerting emails more informative

<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- If this is a hotfix for production, which needs to be deployed after merging
- If this requires manual work to deploy the PR, e.g. a parameter change
- If this has associated internal documentation too
-->

---

### Submitter:

Have you:

* [ ] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
