### PR TITLE
BUG: add env label to prod cluster alerts

### DIFF
--- a/clusters/prod/management/infra-values.yaml
+++ b/clusters/prod/management/infra-values.yaml
@@ -15,7 +15,8 @@ openstack-cluster:
           values:
             defaultRules:
               additionalRuleLabels:
-                cluster: prod-management
+                cluster: management
+                env: prod
             prometheus:
               ingress:
                 hosts:

--- a/clusters/prod/worker/infra-values.yaml
+++ b/clusters/prod/worker/infra-values.yaml
@@ -15,7 +15,8 @@ openstack-cluster:
           values:
             defaultRules:
               additionalRuleLabels:
-                cluster: prod-worker
+                cluster: worker
+                env: prod
             prometheus:
               ingress:
                 hosts:


### PR DESCRIPTION
env label must be prod so we know where the alerts are coming from
 