### PR TITLE
MAINT: enable alerts on dev galaxy

### DIFF
--- a/clusters/dev/galaxy/infra-values.yaml
+++ b/clusters/dev/galaxy/infra-values.yaml
@@ -31,7 +31,7 @@ openstack-cluster:
         release:
           values:
             alertmanager:
-              enabled: false
+              enabled: true
               ingress:
                 hosts:
                   - alertmanager-galaxy.dev.nubes.stfc.ac.uk


### PR DESCRIPTION
enable alerting on dev galaxy - so we can respond to issues as we trial users on it
