### PR TITLE
MAINT: simplify alertmanager routing

### DIFF
--- a/charts/dev/capi-infra/values.yaml
+++ b/charts/dev/capi-infra/values.yaml
@@ -187,42 +187,43 @@ openstack-cluster:
                   smtp_require_tls: false
 
                 route:
-                  receiver: 'null'
-                  routes:
-                    - receiver: 'null'
-                      matchers:
-                      - alertname = "Watchdog"
-                    - receiver: default-receiver
-                      group_wait: 30m
-                      group_interval: 30m
-                      repeat_interval: 2d
-                      group_by: ['cluster', 'service']
-                      matchers:
-                      - severity=~"critical|warning"
+                  receiver: 'default-receiver'
+                  group_by: ['cluster', 'service']
+                  group_wait: 30m
+                  group_interval: 30m
+                  repeat_interval: 2d
 
-                inhibit_rules:
-                  - source_matchers: [severity="critical"]
-                    target_matchers: [severity="warning"]
-                    equal: [alertname, cluster, service]
+                inhibit_rules:                    
+                  # mute warning/info alerts on same service if a critical alert is firing - less noise 
+                  - source_matchers: 
+                    - severity: critical
+                    target_matchers: 
+                      - severity: "warning"
+                    equal: [cluster, service]
 
-                  - source_matchers:
-                      - 'severity = warning'
-                    target_matchers:
-                      - 'severity = info'
-                    equal: [alertname, cluster, service]
-
-                  - source_matchers:
-                      - 'alertname = InfoInhibitor'
-                    target_matchers:
-                      - 'severity = info'
-                    equal: ['namespace']
-
+                  # mute watchdog alert 
+                  #   - this should always be firing 
+                  # mute infoinhibitor alert
+                  #   - not useful by itself
+                  #   - if this is firing, we're suppressing severity=info alerts
+                  #   - infoinhibitor rules should be automatically configured 
                   - target_matchers:
-                      - 'alertname = InfoInhibitor'
+                    - alertname: Watchdog
+                    - alertname: InfoInhibitor
+
+                time_intervals:
+                  - name: officehours
+                    time_intervals:
+                      - times:
+                        - start_time: 07:00
+                          end_time: 18:00
+                        weekdays: ['monday:friday']
+                        location: "Europe/London"
 
                 receivers:
-                - name: 'null'
                 - name: default-receiver
+                  active_time_intervals:
+                    - officehours
                   email_configs:
                   - to: cloud-support@stfc.ac.uk
                     send_resolved: true


### PR DESCRIPTION
Simplify alertmanager routing - we only need one route - for emailing.

Just Inhibit the watchdog and infoinhibitor alerts so they don't send notifications

add a time range where emails are active - during office hours
