### PR TITLE
[Deployment] Rotate prod management keys

### DIFF
--- a/secrets/prod/management/.sops.yaml
+++ b/secrets/prod/management/.sops.yaml
@@ -5,4 +5,4 @@ creation_rules:
           # prod-rotate-key
           - age1cq92796c46d06s43t079xc89exe4vd52rh30c9mcafmne62dxyhqrupl4l
           # prod-argo-key
-          - age1mqqfadar4vz8yfsvfd540nkhwjvxuzmf3hgr95ftp7d0dqnm7ycsfue3kv
+          - age1p9q4tzawn9jh3evsgkuslklm2d4zhwhyhtcfls7n62a8cdpv8vqq7t9hqv

--- a/secrets/prod/management/api-server-fip.yaml
+++ b/secrets/prod/management/api-server-fip.yaml
@@ -10,20 +10,20 @@ sops:
         - recipient: age1cq92796c46d06s43t079xc89exe4vd52rh30c9mcafmne62dxyhqrupl4l
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaUngybXB5L01BQkljVnJN
-            WVROTVhEa1c0eWh0NzZNeDlvN3hsOU5ub1VrCnBLU05WVWRvRjRvNExuZ1JxSFN5
-            UFQ3cU0vamczUmcvOCtSRzVEUlQ0Y2sKLS0tIDVhNHhXUi9KQzlBNVBvRzRIYStq
-            Q0QvZ3J5bkVKdk56N3JpcU1SN1RIQlkK20dSM6Wy+siF2s55kPzgvj2tq6Cy1DnI
-            F3CiG8g6h9bvntNott44tfrRyHkw2wklscN724QAFuuORMMJLRRosg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3RnZMb3lKZC9yL0krUW5m
+            MkxVbGUwODlNclhlYlExL3ZMaWpqbk5STmk4Cnc1aWNwdVg3OXVUR3ZxM2UrMkE2
+            VDZEZE1tU3JycmQ1cC9qRU5vU01KVGsKLS0tIDIwKzZ0QVFDSHNib1R2OGwrcU9X
+            MTJjSVU4U1FITjVGUk5uR3lRZGNPZVEKQkYYDRi3OjFJ9cHYbO1mbU4gnGZ1U4+R
+            cihSWyBikgMJeyTTrbDLWYwqxnsfWQTB2IwQymH/myLtr1nrds5KVw==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1mqqfadar4vz8yfsvfd540nkhwjvxuzmf3hgr95ftp7d0dqnm7ycsfue3kv
+        - recipient: age1p9q4tzawn9jh3evsgkuslklm2d4zhwhyhtcfls7n62a8cdpv8vqq7t9hqv
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzNzd2czAvSHlRcENNNU8r
-            M3hjODJBVnRCQ09iWTliK3EvWGNVblN3S0VNCk11N2toR1JJNitVWUNKakJsRFJa
-            UDZjdHpWNnVwdjdZSFNPYW5qNHErZXcKLS0tIFM0d29OYTZ0endLbzFFVGdvTXdo
-            bitHU3NTbFpkSnpZdFk1aWo0Y2tmeVUKoviWpLRO6Ny0QjmmRfOmde4R1onkXWd5
-            51A8zd1aZxhR6aIyshMRNyLh+kw9fgJ4OxzR/Za5aoxZAn32CIpzgw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYdG8rM1l1cFpYTkJJZ0wr
+            ME52aTV3b0RBc2Vucmo5WFBLTVZHTFBhZXpVClBJRHV6QVBUb2hBQ2JPaUcyaVVG
+            SE9NeEp1MFFwbHM2UkdWTVFiVUgrYUUKLS0tIGFSRXc1TmN0WkFtRlExRVRScmVF
+            dXUxS1lRTWRVOXQ1M0ZrZi9rSUVSeGMK06s5QsNfzYDmcEUS9lCY0DTqylZWLNyP
+            XgSVYS4BPJ2mCxmDHKQHE7kMbEpdj1C6MHWeHU5d73cK10zwTpGm0A==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2024-09-09T12:34:37Z"
     mac: ENC[AES256_GCM,data:c7r07fi0Y9YNLf5hAKv9lWIpdcUeu0DOSSDIbtzs90XbPyhNyHQRw3riAyMLYT3DnswEOvDsaZlmcRdUD3zqiB/HXTAYUp5/xEfecT+87KMBlHWS3bYzMLvS5PRjA0C9gDFMpaEVOn1FIhTmxg/cUEvyEQtCEIH75f+vhDU8AvE=,iv:eLpQG9khB22bOvT8EALpKTMqfiqck6di5RV0hkCkULk=,tag:Y96Go4wi14yPl4RdDk8/yQ==,type:str]

--- a/secrets/prod/management/app-creds.yaml
+++ b/secrets/prod/management/app-creds.yaml
@@ -19,20 +19,20 @@ sops:
         - recipient: age1cq92796c46d06s43t079xc89exe4vd52rh30c9mcafmne62dxyhqrupl4l
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYSGtUY2dZV01pUDBUWTdN
-            SDhWVXhYelR5aGg2WnN3RTZxeHJjYVR3VndzCllpUmU4QkhRd1NYc3l1RTlpbVJU
-            R0JrSDF1enVRNmNyUzVER2Q5TDlBNlEKLS0tIE9Pd3lrTS96clpYZjRHOHl0ZEF5
-            OTNMYUxsc3U3YmI2aWxIT3NLVGpnNWsKVXF9gGzWEbA7qt26mAE+IWdOsj2P6D9N
-            lZOENCi856VeNhwRHtBlXdEWq2yOKsYnwmxr0Jj1cEx0tP9wi5BEtg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQbk11dE9xSGlvUTI3YVBa
+            YTA4eGtxNldEcWVMTFVmdGNwc3BYUExuOGlBClZCN3B3OUlVME0xb1UwRDZlNnJo
+            QmtXTXg3ZG5xUjltWGlWY0ZMemlRQncKLS0tIDJEbGIwTGJlTFpVeEdYQk5DeXlp
+            eWxzOGxjbHRIQlM2eW1NSkZwdEs2ZEUKbUIRw6oW7Q0KVemL8mD2Dty6TBu4Q9mN
+            I6c22821F017jwUzo1hHIjDYT7m0yzrJmIt2+Zmq+yUfM2GYc0f7yw==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1mqqfadar4vz8yfsvfd540nkhwjvxuzmf3hgr95ftp7d0dqnm7ycsfue3kv
+        - recipient: age1p9q4tzawn9jh3evsgkuslklm2d4zhwhyhtcfls7n62a8cdpv8vqq7t9hqv
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzMDdobjRPOGtNVnVtYm1S
-            KytibjVQc2hXdDl2UVdiTzdndjFUR1BuR1FZCmd1SVUvd1krUlRNNXVLLzFXYzdS
-            MWxidTh2Z1YxNXNHZElLOVg4aEdKKzgKLS0tIERaN2dJQzJLbE9WaEx1eXBObUNt
-            WGdMS1ZuK3FsTXpmMmZ1bmduYjRVMWMKYg13vgZBl/VrMZBV67ew0TdaEydyPav7
-            Jex1iXIdYERMX7nnPYtbuofIkh5W+QE3wJg1i0LJ0HiwqpbIdjjM0w==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlTnZFL1VuQmM5YWJpWTA3
+            MHp1UnR6QVplb3RoQVlhZWNDREpzZGdUSEIwCmwxbStSeURnVTVHcXR0Um9qVzFF
+            NnBPTC8wNkkxRTc0TmFQUm5WQ0d6MlUKLS0tIGV0czNXWERSbXBPQWxoM2RkSTEx
+            ZzcySjI5a0l2ZzVNNHpSRU9NKzV1TkkKc08vn+9PGCdfEZJyRAzYzJiGkHukmbnN
+            UvAVLGsB1NO+i/Ufn4GB9jbpe0rpJ7r3y8cJe9vRXUc9QpNbdZjgCg==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2024-09-09T10:42:24Z"
     mac: ENC[AES256_GCM,data:ZyCUO1cbW5uI4INuu127X0wTAr3pg7ATvNkHMVIdTwRBnUQwtARBvpXI4E9xdMfdpoOGqyEPsOHpmacR3JGmzC6w56HXyna6ViwZH0+CL6KU6i5FvUMB6d7STjjXTC9fHcD/ro/pwao1efSbIG4mD5bC/hnMG5I+r2fLchFN6aw=,iv:y1ZCZIZgjEn5Jwi0K2eGQQZCZuTDxRMM0jz5YVomzD4=,tag:at8h5XWpZ3Yiim8xxzRosw==,type:str]


### PR DESCRIPTION
Recreating the prod management cluster
Original private key no longer owned

### Description:

<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- If this is a hotfix for production, which needs to be deployed after merging
- If this requires manual work to deploy the PR, e.g. a parameter change
- If this has associated internal documentation too
-->

---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
