### PR TITLE
Update ingress IPs and DNS entries for prod clusters

### DIFF
--- a/clusters/prod/management/infra-values.yaml
+++ b/clusters/prod/management/infra-values.yaml
@@ -7,7 +7,8 @@ openstack-cluster:
           values:
             controller:
               service:
-                loadBalancerIP: "130.246.81.161"
+                # *.prod-mgmt.nubes.stfc.ac.uk
+                loadBalancerIP: "130.246.80.233"
 
     monitoring:
       kubePrometheusStack:
@@ -20,25 +21,25 @@ openstack-cluster:
             prometheus:
               ingress:
                 hosts:
-                  - prometheus-mgmt.prod.nubes.stfc.ac.uk
+                  - prometheus.prod-mgmt.nubes.stfc.ac.uk
                 tls:
                   - hosts:
-                      - prometheus-mgmt.prod.nubes.stfc.ac.uk
+                      - prometheus.prod-mgmt.nubes.stfc.ac.uk
                     secretName: tls-keypair
             grafana:
               ingress:
                 hosts:
-                  - grafana-mgmt.prod.nubes.stfc.ac.uk
+                  - grafana.prod-mgmt.nubes.stfc.ac.uk
                 tls:
                   - hosts:
-                      - grafana-mgmt.prod.nubes.stfc.ac.uk
+                      - grafana.prod-mgmt.nubes.stfc.ac.uk
                     secretName: tls-keypair
             alertmanager:
               enabled: true
               ingress:
                 hosts:
-                  - alertmanager-mgmt.prod.nubes.stfc.ac.uk
+                  - alertmanager.prod-mgmt.nubes.stfc.ac.uk
                 tls:
                   - hosts:
-                      - alertmanager-mgmt.prod.nubes.stfc.ac.uk
+                      - alertmanager.prod-mgmt.nubes.stfc.ac.uk
                     secretName: tls-keypair

--- a/clusters/prod/worker/infra-values.yaml
+++ b/clusters/prod/worker/infra-values.yaml
@@ -7,6 +7,7 @@ openstack-cluster:
           values:
             controller:
               service:
+                # *.prod-worker.nubes.stfc.ac.uk
                 loadBalancerIP: "130.246.80.243"
 
     monitoring:
@@ -20,25 +21,25 @@ openstack-cluster:
             prometheus:
               ingress:
                 hosts:
-                  - prometheus-worker.prod.nubes.stfc.ac.uk
+                  - prometheus.prod-worker.nubes.stfc.ac.uk
                 tls:
                   - hosts:
-                      - prometheus-worker.prod.nubes.stfc.ac.uk
+                      - prometheus.prod-worker.nubes.stfc.ac.uk
                     secretName: tls-keypair
             grafana:
               ingress:
                 hosts:
-                  - grafana-worker.prod.nubes.stfc.ac.uk
+                  - grafana.prod-worker.nubes.stfc.ac.uk
                 tls:
                   - hosts:
-                      - grafana-worker.prod.nubes.stfc.ac.uk
+                      - grafana.prod-worker.nubes.stfc.ac.uk
                     secretName: tls-keypair
             alertmanager:
               enabled: true
               ingress:
                 hosts:
-                  - alertmanager-worker.prod.nubes.stfc.ac.uk
+                  - alertmanager.prod-worker.nubes.stfc.ac.uk
                 tls:
                   - hosts:
-                      - alertmanager-worker.prod.nubes.stfc.ac.uk
+                      - alertmanager.prod-worker.nubes.stfc.ac.uk
                     secretName: tls-keypair


### PR DESCRIPTION
### Description:
Updates the ingress IPs to reflect the wildcard DNS entry Switch the existing services to start using the wildcard subdomains

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- If this is a hotfix for production, which needs to be deployed after merging
- If this requires manual work to deploy the PR, e.g. a parameter change
- If this has associated internal documentation too
-->

---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
