### PR TITLE
BUG: Point staging worker to another kubeapi FIP

### DIFF
--- a/secrets/staging/worker/api-server-fip.yaml
+++ b/secrets/staging/worker/api-server-fip.yaml
@@ -1,6 +1,6 @@
 openstack-cluster:
     apiServer:
-        floatingIP: ENC[AES256_GCM,data:dCNJSVOi/3KW5v3IrDM=,iv:tAJePb5goONYGFfLzrsLJUaHZufFR93znoD5OABfyJo=,tag:3elZdMhJ2G1ycsTu/rreqg==,type:str]
+        floatingIP: ENC[AES256_GCM,data:SkwvYu8Ru1YLxSL4jM4=,iv:4tLaAVy0F7EwE5dTzUEx2aVnLN20tQ0K2vPF3VArfkg=,tag:ivx0GSJI4Dm9pa6UJDu7Ug==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -25,8 +25,8 @@ sops:
             UnZrS2dDWjB1ckc5ayt3YzNJUjRVdXcKehx6NcP7TxevTJfQrnTiElE9D+FgRdUx
             lIaqNNEJFEb3e2RazNs+BqUCW4+mAA+XOzARrWZI1qpa2S3IID2MEw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-09-10T15:50:03Z"
-    mac: ENC[AES256_GCM,data:VW1nDzZW/T9hS3ACs3h83ZN/OXP+i55ncRCFNoMKXEniNqOJIi2TyE4SOlFzzIp2RNhjLoKWh+Sk/A6UsQmLZ/b5WUJ4m1Yek6qhxY2FBpiYLqrXAePJ2cx4ED0zF7MTpiI2OZPuP+SFKHANzTp7og/Qwv0jQdxKchezxZ07rdM=,iv:/k+X11iLfRZYOrJe2fXmnErsYceHYScOhNe1F62NSKA=,tag:bTD1d3Gp23pblTOdssJK5A==,type:str]
+    lastmodified: "2024-10-31T15:43:51Z"
+    mac: ENC[AES256_GCM,data:9hLTXXBtKURXmmSk+oR3+0HBh3asZGa2IeD04RZ5yvdJG/B+UWjLDEGv1iVAsXA7PxjAB1zGvowDwWHTaoI3nk+LErImSzNCnsiKUSaYIRCHmymeT7o94l67Wfht/2w0Xk+9mxFTLqbAFSSIwdiZDJJZg21MpX/uRPDJ0pNPpNM=,iv:AsiOfSw/Z0N/OurLizrxLAY/Lr4RnzPKYWMZ7y5ejDo=,tag:FrOVWjVwFTRzS5ACTZTpiA==,type:str]
     pgp: []
     unencrypted_regex: ^(apiVersion|metadata|kind|type)$
     version: 3.9.0


### PR DESCRIPTION


### Description:
This was using the same FIP as the prod ingress, causing the two to fight. Allocate a new kubeAPI FIP and point to that
<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- If this is a hotfix for production, which needs to be deployed after merging
- If this requires manual work to deploy the PR, e.g. a parameter change
- If this has associated internal documentation too
-->

---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
