### PR TITLE
Misc fixes across deployed clusters

### DIFF
--- a/charts/prod/capi-infra/requirements.yaml
+++ b/charts/prod/capi-infra/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-  - repository: https://azimuth-cloud.github.io/capi-helm-charts
-    name: openstack-cluster
-    version: 0.10.1

--- a/charts/prod/cluster-api-addon-provider/requirements.yaml
+++ b/charts/prod/cluster-api-addon-provider/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-  - repository: https://azimuth-cloud.github.io/cluster-api-addon-provider
-    name: cluster-api-addon-provider
-    version: 0.6.1

--- a/clusters/dev/management/infra-values.yaml
+++ b/clusters/dev/management/infra-values.yaml
@@ -1,14 +1,4 @@
 openstack-cluster:
-  controlPlane:
-    machineCount: 3
-
-  nodeGroups:
-    - name: default-md-0
-      machineCount: 2
-
-  nodeGroupDefaults:
-    machineFlavor: l3.nano
-
   addons:
     ingress:
       enabled: true

--- a/clusters/staging/management/infra-values.yaml
+++ b/clusters/staging/management/infra-values.yaml
@@ -1,14 +1,4 @@
 openstack-cluster:
-  controlPlane:
-    machineCount: 3
-
-  nodeGroups:
-    - name: default-md-0
-      machineCount: 2
-
-  nodeGroupDefaults:
-    machineFlavor: l3.nano
-
   addons:
     ingress:
       enabled: true


### PR DESCRIPTION
### Description:
- Fix the requirements.yaml getting pulled in instead of chart.yaml on prod the KCP to fail to update with an older chart
- Don't override the defaults across our management clusters, use the safest option which is in the chart defaults as these are the hardest to recover
<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- If this is a hotfix for production, which needs to be deployed after merging
- If this requires manual work to deploy the PR, e.g. a parameter change
- If this has associated internal documentation too
-->

---

### Submitter:

Have you:

* [ ] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
