### PR TITLE
MAINT: Bump CAPI image and version on dev

### DIFF
--- a/charts/dev/capi-infra/Chart.yaml
+++ b/charts/dev/capi-infra/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: capi-openstack-cluster
-version: 1.0.0
+version: 1.1.0
 dependencies:
   - repository: https://azimuth-cloud.github.io/capi-helm-charts
     name: openstack-cluster

--- a/charts/dev/capi-infra/values.yaml
+++ b/charts/dev/capi-infra/values.yaml
@@ -1,6 +1,6 @@
 openstack-cluster:
-  kubernetesVersion: "1.28.7"
-  machineImage: "capi-ubuntu-2004-kube-v1.28.7-2024-03-01"
+  kubernetesVersion: "1.29.10"
+  machineImage: "capi-ubuntu-2204-kube-v1.29.10-2024-11-15"
 
   # The PEM-encoded CA certificate for openstack.stfc.ac.uk
   # this expires 2023-12-05T23:59:59Z (UTC)


### PR DESCRIPTION
### Description:
Bumps the CAPI image and version on dev in prep for rollout to staging and prod next week

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- If this is a hotfix for production, which needs to be deployed after merging
- If this requires manual work to deploy the PR, e.g. a parameter change
- If this has associated internal documentation too
-->

---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
