### PR TITLE
[DEPLOYMENT] Scale up worker nodes

### DIFF
--- a/clusters/staging/worker/infra-values.yaml
+++ b/clusters/staging/worker/infra-values.yaml
@@ -1,4 +1,8 @@
 openstack-cluster:
+
+  nodeGroups:
+      machineCount: 5
+
   addons:
     ingress:
       enabled: true


### PR DESCRIPTION
Allow autoscaler rules for manila-csi to work

### Description:

Increase worker nodes on the staging worker cluster to allow autoscaler rules for manila-csi to work
Anti-affinity rules blocking the scaler from creating 3 replicas on 2 nodes

---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
