### PR TITLE
Promotion of victoria metrics, Staging -> Prod

### DIFF
--- a/charts/prod/manila-csi/Chart.yaml
+++ b/charts/prod/manila-csi/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: manila-csi
+version: 1.0.0
+dependencies:
+# https://github.com/kubernetes/cloud-provider-openstack/tree/master/charts/cinder-csi-plugin
+- name: openstack-manila-csi
+  version: 2.31.0
+  repository: https://kubernetes.github.io/cloud-provider-openstack
+# https://github.com/ceph/ceph-csi/tree/devel/charts/ceph-csi-cephfs
+- name: ceph-csi-cephfs
+  version: 3.11.0
+  repository: https://ceph.github.io/csi-charts

--- a/charts/prod/manila-csi/templates/manila-sc.yaml
+++ b/charts/prod/manila-csi/templates/manila-sc.yaml
@@ -1,0 +1,18 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-manila-cephfs
+provisioner: cephfs.manila.csi.openstack.org
+allowVolumeExpansion: true
+parameters:
+  # Manila share type
+  type: cephfs
+
+  csi.storage.k8s.io/provisioner-secret-name: csi-manila-secret
+  csi.storage.k8s.io/provisioner-secret-namespace: kube-system
+  csi.storage.k8s.io/controller-expand-secret-name: csi-manila-secret
+  csi.storage.k8s.io/controller-expand-secret-namespace: kube-system
+  csi.storage.k8s.io/node-stage-secret-name: csi-manila-secret
+  csi.storage.k8s.io/node-stage-secret-namespace: kube-system
+  csi.storage.k8s.io/node-publish-secret-name: csi-manila-secret
+  csi.storage.k8s.io/node-publish-secret-namespace: kube-system

--- a/charts/prod/manila-csi/values.yaml
+++ b/charts/prod/manila-csi/values.yaml
@@ -1,0 +1,11 @@
+openstack-manila-csi:
+  # Base name of the CSI Manila driver
+  driverName: manila.csi.openstack.org
+
+  # Enabled Manila share protocols
+  shareProtocols:
+  - protocolSelector: CEPHFS
+    fsGroupPolicy: None
+    fwdNodePluginEndpoint:
+      dir: /var/lib/kubelet/plugins/cephfs.csi.ceph.com
+      sockFile: csi.sock

--- a/charts/prod/victoria-metrics/Chart.yaml
+++ b/charts/prod/victoria-metrics/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: victoria-metrics-cluster
+version: 1.0.0
+dependencies:
+# https://github.com/VictoriaMetrics/helm-charts/releases?q=cluster&expanded=true
+- name: victoria-metrics-cluster
+  version: 0.11.18
+  repository: https://victoriametrics.github.io/helm-charts/

--- a/charts/prod/victoria-metrics/values.yaml
+++ b/charts/prod/victoria-metrics/values.yaml
@@ -1,0 +1,48 @@
+victoria-metrics-cluster:
+  vmselect:
+    replicaCount: 5
+
+    ingress:
+      enabled: true
+      ingressClassName: nginx
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+        cert-manager.io/cluster-issuer: "self-signed"
+      hosts:
+        - name: select.vm.example.com
+          path: /
+          port: http
+      tls:
+        - secretName: vm-ingress-tls
+          hosts:
+            - select.vm.example.com
+
+
+  vminsert:
+    replicaCount: 5
+
+    ingress:
+      enabled: true
+      ingressClassName: nginx
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+        cert-manager.io/cluster-issuer: "self-signed"
+      hosts:
+        - name: insert.vm.example.com
+          path: /
+          port: http
+      tls:
+        - secretName: vm-ingress-tls
+          hosts:
+            - insert.vm.example.com              
+
+  vmstorage:
+    retentionPeriod: 1 # month
+    replicaCount: 5
+
+    persistentVolume:
+      enabled: true
+      existingClaim: ""
+
+      size: 10Gi
+      storageClass: "csi-manila-cephfs"

--- a/clusters/prod/worker/apps.yaml
+++ b/clusters/prod/worker/apps.yaml
@@ -91,7 +91,10 @@ spec:
           allowEmpty: true
         syncOptions:
           - CreateNamespace=true
-
+  
+  # Clusterrole and clusterrolebinding get updated after creation by the helm chart
+  # this causes ArgoCD outofsync issues so we ignore differences 
+  # rules gets updated 
   templatePatch: |
     {{- if eq .name "manila-csi" }}
       spec:

--- a/clusters/prod/worker/apps.yaml
+++ b/clusters/prod/worker/apps.yaml
@@ -1,0 +1,109 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cloud-deployed-apps
+  namespace: argocd
+spec:
+  destination:
+    namespace: argocd
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    repoURL: https://github.com/stfc/cloud-deployed-apps.git
+    targetRevision: main
+    path: clusters/prod/worker
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: true
+      allowEmpty: true
+    syncOptions:
+      - CreateNamespace=true
+
+---
+
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: prod-worker-apps
+  namespace: argocd
+spec:
+  goTemplate: true
+  generators:
+    - list:
+        elements:
+          - name: "argocd"
+            chartName: argocd
+
+            # NOTE: each chart needs a valuesFile for this to work
+            # so create one for each chart - even if its empty
+
+            # argocd and all dependencies use the same file "argocd-setup-values.yaml"
+            valuesFile: ../../../clusters/prod/worker/argocd-setup-values.yaml
+            namespace: argocd
+
+          - name: "cert-manager"
+            chartName: cert-manager
+            namespace: cert-manager
+            valuesFile: ../../../clusters/prod/worker/argocd-setup-values.yaml
+
+          - name: cluster-api-addon-provider
+            chartName: cluster-api-addon-provider
+            namespace: clusters
+            valuesFile: ../../../clusters/prod/worker/argocd-setup-values.yaml
+          
+          - name: manila-csi
+            chartName: manila-csi
+            namespace: manila-csi
+            valuesFile: ../../../clusters/prod/worker/argocd-setup-values.yaml
+
+          - name: victoria-metrics
+            chartName: victoria-metrics
+            namespace: victoria-metrics
+            valuesFile: ../../../clusters/prod/worker/vicmet-values.yaml
+
+
+  syncPolicy:
+    # Don't remove everything if we remove the appset
+    preserveResourcesOnDeletion: true
+
+  template:
+    metadata:
+      name: "{{.name}}"
+      namespace: argocd
+    spec:
+      project: default
+      source:
+        repoURL: "https://github.com/stfc/cloud-deployed-apps.git"
+        targetRevision: main
+        path: "charts/prod/{{.chartName}}"
+        helm:
+          valueFiles:
+            - "{{.valuesFile}}"
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: "{{.namespace}}"
+
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+          allowEmpty: true
+        syncOptions:
+          - CreateNamespace=true
+
+  templatePatch: |
+    {{- if eq .name "manila-csi" }}
+      spec:
+        ignoreDifferences:
+          - group: rbac.authorization.k8s.io
+            kind: ClusterRole
+            name: manila-csi-openstack-manila-csi-controllerplugin
+            jsonPointers:
+              - /rules
+          - group: rbac.authorization.k8s.io
+            kind: ClusterRole
+            name: manila-csi-openstack-manila-csi-nodeplugin
+            jsonPointers:
+              - /rules
+    {{- end }}

--- a/clusters/prod/worker/argocd-setup-values.yaml
+++ b/clusters/prod/worker/argocd-setup-values.yaml
@@ -1,0 +1,3 @@
+argo-cd:
+  global:
+    domain: argocd.prod-worker.nubes.stfc.ac.uk

--- a/clusters/prod/worker/infra-values.yaml
+++ b/clusters/prod/worker/infra-values.yaml
@@ -1,4 +1,7 @@
 openstack-cluster:
+  nodeGroups:
+    - name: default-md-0
+      machineCount: 5
   addons:
     ingress:
       enabled: true

--- a/clusters/prod/worker/vicmet-values.yaml
+++ b/clusters/prod/worker/vicmet-values.yaml
@@ -1,0 +1,1 @@
+#Placeholder file for cluster specific values


### PR DESCRIPTION
### Description:

Copied app charts from staging to prod
Created new cluster files comparable to staging, changed to point to prod values
Creating a running prod version of Victoria-Metrics

---

### Submitter:

Have you:

* [ ] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
