### PR TITLE
BUG: set proper redirect url

### DIFF
--- a/clusters/dev/worker/materials-galaxy-values.yaml
+++ b/clusters/dev/worker/materials-galaxy-values.yaml
@@ -2,7 +2,7 @@ oauth2-proxy:
 
 
   extraArgs:
-    redirect-url: "https://galaxy.dev.nubes.stfc.ac.uk/oauth2/callback"
+    redirect-url: "https://galaxy.dev-worker.nubes.stfc.ac.uk/oauth2/callback"
 
 galaxy:
   ingress:


### PR DESCRIPTION
Galaxy redirect after oidc needs to match the new url galaxy.dev-worker.* rather than galaxy.dev.*
