### PR TITLE
Promote galaxy

### DIFF
--- a/charts/staging/materials-galaxy/Chart.yaml
+++ b/charts/staging/materials-galaxy/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: materials-galaxy
+version: 1.0.0
+dependencies:
+# https://github.com/galaxyproject/galaxy-helm
+  - repository: https://raw.githubusercontent.com/CloudVE/helm-charts/master/
+    name: galaxy
+    version: 5.17.0
+# https://github.com/oauth2-proxy/manifests/tree/main/helm/oauth2-proxy
+  - repository: "https://oauth2-proxy.github.io/manifests"
+    name: oauth2-proxy
+    version: 7.7.22
+# https://github.com/zalando/postgres-operator/tree/master/charts/postgres-operator
+  - repository: "https://opensource.zalando.com/postgres-operator/charts/postgres-operator"
+    name: postgres-operator
+    version: 1.13.0
+# https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq-cluster-operator
+  - repository: "https://charts.bitnami.com/bitnami"
+    name: rabbitmq-cluster-operator
+    version: 4.3.24

--- a/charts/staging/materials-galaxy/secrets-templates/materials-galaxy.yaml
+++ b/charts/staging/materials-galaxy/secrets-templates/materials-galaxy.yaml
@@ -1,0 +1,36 @@
+oauth2-proxy:
+
+  # IRIS IAM CLIENT CREDENTIALS
+  config:
+    clientID: iris-iam-client-id
+    clientSecret: iris-iam-secret
+    # Create a new secret with the following command
+    # openssl rand -base64 32 | head -c 32 | base64
+    cookieSecret: "XXXXXXXXXXXXXXXX"
+  
+  # if you want to setup galaxy where only specific emails have access
+  # USE EITHER THIS OR RESTRICT BY OIDC GROUP 
+  authenticatedEmailsFile:
+    # if you're using oidc - set this to false
+    enabled: true
+    restricted_access: |-
+      user1@example.com
+      user2@example.com
+  
+  # if you want to setup galaxy where only a specific IAM group has access
+  # USE EITHER THIS OR RESTRICT BY EMAILS ABOVE
+#  extraArgs:
+#    allowed-group: "stfc-cloud/admins"
+
+galaxy:
+  postgresql:
+      # a random consistent password for postgres galaxydbuser
+      # can't auto-generate a password because of argo-helm issues when it tries to reconcile
+      galaxyDatabasePassword: <random-password>
+  configs:
+    galaxy.yml:
+      galaxy:
+        # comma spaced list of admin emails
+        admin_users: "user1@example.com,user2@example.com"
+
+

--- a/charts/staging/materials-galaxy/templates/nginx-configmap.yaml
+++ b/charts/staging/materials-galaxy/templates/nginx-configmap.yaml
@@ -1,0 +1,115 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "galaxy.fullname" . }}-nginx-conf
+  labels:
+    {{- include "galaxy.labels" . | nindent 4 }}
+data:
+  nginx.conf: |
+    worker_processes  4;
+
+    events {
+        worker_connections  1024;
+    }
+
+    http {
+        default_type  application/octet-stream;
+        include /etc/nginx/mime.types;
+        sendfile        on;
+        keepalive_timeout  65;
+        index   index.html index.php index.htm;
+
+        gzip  on;
+        gzip_http_version 1.1;
+        gzip_vary on;
+        gzip_comp_level 6;
+        gzip_proxied any;
+        gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/javascript;
+        gzip_buffers 16 8k;
+        proxy_read_timeout 600;
+        client_max_body_size {{ .Values.galaxy.nginx.conf.client_max_body_size }};
+
+        map $http_x_forwarded_proto $proxy_x_forwarded_proto {
+          default $http_x_forwarded_proto;
+          '' $scheme;
+        }
+
+        server {
+            listen {{ .Values.galaxy.nginx.containerPort }};
+            server_name galaxy;
+            underscores_in_headers on;
+
+            location {{ template "galaxy.add_trailing_slash" .Values.galaxy.ingress.path }}static {
+                alias {{ .Values.galaxy.nginx.galaxyStaticDir }};
+                expires 24h;
+            }
+
+            # Auth request configuration
+            location /oauth2 {
+                proxy_pass http://{{.Release.Name}}-oauth2-proxy:80;
+                proxy_set_header X-Original-URI $request_uri;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header Host $host;
+            }
+
+            location {{ template "galaxy.add_trailing_slash" .Values.galaxy.ingress.path }} {
+                auth_request /oauth2/auth;
+                error_page 401 = /oauth2/sign_in;
+                auth_request_set $email $upstream_http_x_auth_request_email;
+
+                proxy_set_header Host $http_host;
+                proxy_set_header REMOTE_USER $email;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+                proxy_set_header X-Url-Scheme $proxy_x_forwarded_proto;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_pass http://{{ template "galaxy.fullname" . }}-galaxy:8080;
+            }
+
+            location ^~ {{ template "galaxy.add_trailing_slash" .Values.galaxy.ingress.path }}admin_toolshed/static {
+                auth_request /oauth2/auth;
+                error_page 401 = /oauth2/sign_in;
+                auth_request_set $email $upstream_http_x_auth_request_email;
+
+                proxy_set_header Host $http_host;
+                proxy_set_header REMOTE_USER $email;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+                proxy_set_header X-Url-Scheme $proxy_x_forwarded_proto;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_pass http://{{ template "galaxy.fullname" . }}-galaxy:8080;
+                expires 24h;
+            }
+
+            location ~ ^{{ template "galaxy.add_trailing_slash" .Values.galaxy.ingress.path }}api/dataset_collections/([^/]+)/download/?$ {
+                proxy_buffering off;
+                auth_request /oauth2/auth;
+                error_page 401 = /oauth2/sign_in;
+                auth_request_set $email $upstream_http_x_auth_request_email;
+
+                proxy_set_header Host $http_host;
+                proxy_set_header REMOTE_USER $email;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+                proxy_set_header X-Url-Scheme $proxy_x_forwarded_proto;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_pass http://{{ template "galaxy.fullname" . }}-galaxy:8080;
+            }
+
+            location {{ template "galaxy.add_trailing_slash" .Values.galaxy.ingress.path }}_x_accel_redirect/ {
+                internal;
+                alias /;
+                add_header X-Frame-Options SAMEORIGIN;
+                add_header X-Content-Type-Options nosniff;
+            }
+{{- if .Values.galaxy.trainingHook.enabled }}
+            location /training-material/ {
+                proxy_pass {{ .Values.galaxy.trainingHook.url }};
+            }
+{{- end }}
+
+        # end server
+        }
+    # end http
+    }

--- a/charts/staging/materials-galaxy/values.yaml
+++ b/charts/staging/materials-galaxy/values.yaml
@@ -1,0 +1,367 @@
+galaxy:
+  # RBAC is defined by admins once service is up
+  rbac:
+    enabled: true
+
+  persistence:
+    enabled: true
+    # must support readwritemany
+    storageClass: longhorn
+    size: 10Gi
+
+  setupJob:
+    ttlSecondsAfterFinished: null
+    createDatabase: true
+    
+    # Download configuration files and the tools directory from an archive via a job at startup
+    # You can enable it to install "default" galaxy tools
+    # since these tools are mostly for biological sciences - this is disabled in materials galaxy   
+    downloadToolConfs:
+      enabled: false
+
+  #- Allow users to specify extra init containers
+  # We use init containers to install tools which aren't available via galaxy toolshed
+  # TODO: find a better way to do this so we can change tool versions easily
+  extraInitContainers: 
+    - name: clone-muon-tools
+      applyToJob: false
+      applyToWeb: true
+      applyToWorkflow: false
+      image: "alpine/git:latest"
+      command: ['sh', '-c', 'git clone https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools.git --depth 1 --branch main {{.Values.persistence.mountPath}}/muon-galaxy-tools || true']
+      volumeMounts:
+        - name: galaxy-data
+          mountPath: "{{.Values.persistence.mountPath}}"
+    - name: clone-larch-tools
+      applyToJob: false
+      applyToWeb: true
+      applyToWorkflow: false
+      image: "alpine/git:latest"
+      command: ['sh', '-c', 'git clone https://github.com/MaterialsGalaxy/larch-tools.git --depth 1 --branch main {{.Values.persistence.mountPath}}/larch-tools || true']
+      volumeMounts:
+        - name: galaxy-data
+          mountPath: "{{.Values.persistence.mountPath}}"
+
+  ingress:
+    # used in galaxy configuration
+    path: "/"
+    enabled: true
+    ingressClassName: nginx
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
+      cert-manager.io/cluster-issuer: "self-signed"
+    # enabled by default
+    canary:
+      enabled: false
+    hosts:
+    - host: "galaxy.example.com"
+      paths:
+        - path: "/"
+    tls:
+    - hosts:
+      - "galaxy.example.com"
+      secretName: galaxy-tls
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 1G
+      ephemeral-storage: 1Gi
+    limits:
+      cpu: 3
+      memory: 7G
+      ephemeral-storage: 10Gi
+
+  # standalone db to reduce galaxy memory footprint
+  postgresql:
+    enabled: true
+
+    deploy: false
+
+  # do not mount cloud-hosted Galaxy reference data and tools
+  refdata:
+    enabled: false
+
+  configs:
+    # define how to use other job runners here:
+    # - slurm, drmaa, pulsar etc
+    # currently setup to use kubernetes and local
+    # job_conf.yml:
+
+    # galaxy configuration
+    galaxy.yml:
+      galaxy:
+        use_remote_user: true
+        # we don't need to set this as there is no way to access galaxy other than through ingress 
+        # which redirects every call to oauth2-proxy via nginx pod
+        remote_user_secret: null
+
+        # admin user config
+        allow_user_deletion: true
+        allow_user_impersonation: true
+
+        # user privacy
+        expose_user_email: true
+
+        # must set quota via admin interface to be enforced
+        # applies to individual users
+        enable_quotas: true
+
+        # service info
+        organization_name: "galaxy cloud cape"
+        organization_url: null
+    
+    integrated_tool_panel.xml: |-
+      <?xml version='1.0' encoding='utf-8'?>
+      <toolbox monitor="true">
+        <section id="get_data" name="Get Data">
+        </section>
+        <label id="muon_label" text="Muons" />
+        <section id="muspinsim" name="MuSpinSim">
+        </section>
+        <section id="muon_stopping_sites" name="Muon Stopping Sites">
+        </section>
+        <section id="muon_other" name="Other Muon Tools">
+        </section>
+        <label id="xas_label" text="xas" />
+        <label id="other_tools" text="Other Tools" />
+        <section id="file_conversion" name="File Conversion">
+        </section>
+        <section id="collection_operations" name="Collection Operations">
+        </section>
+      </toolbox>
+
+    tool_conf.xml: |-
+      <?xml version='1.0' encoding='utf-8'?>
+      <toolbox monitor="true">
+        <section id="get_data" name="Get Data">
+          <tool file="data_source/upload.xml" />
+        </section>
+        <label id="muon_label" text="Muons" />
+        <section id="muspinsim" name="MuSpinSim">
+          <tool file="{{.Values.persistence.mountPath}}/muon-galaxy-tools/muspinsim_combine/muspinsim_combine.xml"/>
+          <tool file="{{.Values.persistence.mountPath}}/muon-galaxy-tools/muspinsim_config/muspinsim_config.xml"/>
+          <tool file="{{.Values.persistence.mountPath}}/muon-galaxy-tools/muspinsim_plot/muspinsim_plot.xml"/>
+          <tool file="{{.Values.persistence.mountPath}}/muon-galaxy-tools/muspinsim/muspinsim.xml"/>
+        </section>
+        <section id="muon_stopping_sites" name="Muon Stopping Sites">
+          <tool file="{{.Values.persistence.mountPath}}/muon-galaxy-tools/pm_muairss_read/pm_muairss_read.xml"/>
+          <tool file="{{.Values.persistence.mountPath}}/muon-galaxy-tools/pm_uep_opt/pm_uep_opt.xml"/>
+          <tool file="{{.Values.persistence.mountPath}}/muon-galaxy-tools/pm_symmetry/pm_symmetry.xml"/>
+        </section>
+        <section id="muon_other" name="Other Muon Tools">
+          <tool file="{{.Values.persistence.mountPath}}/muon-galaxy-tools/mudirac/mudirac.xml"/>
+          <tool file="{{.Values.persistence.mountPath}}/muon-galaxy-tools/pm_asephonons/pm_asephonons.xml"/>
+          <tool file="{{.Values.persistence.mountPath}}/muon-galaxy-tools/pm_nq/pm_nq.xml"/>
+        </section>
+        <label id="xas_label" text="xas" />
+        <tool file="{{.Values.persistence.mountPath}}/larch-tools/larch_select_paths/larch_select_paths.xml" />
+        <tool file="{{.Values.persistence.mountPath}}/larch-tools/larch_plot/larch_plot.xml" />
+        <tool file="{{.Values.persistence.mountPath}}/larch-tools/larch_athena/larch_athena.xml" />
+        <tool file="{{.Values.persistence.mountPath}}/larch-tools/larch_artemis/larch_artemis.xml" />
+        <tool file="{{.Values.persistence.mountPath}}/larch-tools/larch_feff/larch_feff.xml" />
+        <tool file="{{.Values.persistence.mountPath}}/larch-tools/larch_lcf/larch_lcf.xml" />
+        <tool file="{{.Values.persistence.mountPath}}/larch-tools/larch_criteria_report/larch_criteria_report.xml" />
+        <label id="other_tools" text="Other Tools" />
+        <section id="file_conversion" name="File Conversion">
+          <tool file="{{.Values.persistence.mountPath}}/muon-galaxy-tools/cif2cell/cif2cell.xml" />
+        </section>
+        <section id="collection_operations" name="Collection Operations">
+          <tool file="${model_tools_path}/unzip_collection.xml" />
+          <tool file="${model_tools_path}/zip_collection.xml" />
+          <tool file="${model_tools_path}/filter_failed_collection.xml" />
+          <tool file="${model_tools_path}/filter_empty_collection.xml" />
+          <tool file="${model_tools_path}/flatten_collection.xml" />
+          <tool file="${model_tools_path}/merge_collection.xml" />
+          <tool file="${model_tools_path}/relabel_from_file.xml" />
+          <tool file="${model_tools_path}/filter_from_file.xml" />
+          <tool file="${model_tools_path}/sort_collection_list.xml" />
+          <tool file="${model_tools_path}/tag_collection_from_file.xml" />
+          <tool file="${model_tools_path}/apply_rules.xml" />
+          <tool file="${model_tools_path}/build_list.xml" />
+          <tool file="${model_tools_path}/extract_dataset.xml" />
+        </section>
+      </toolbox>
+
+  extraFileMappings:
+    /galaxy/server/static/welcome.html:
+      useSecret: false
+      applyToJob: false
+      applyToWeb: true
+      applyToSetupJob: true
+      applyToWorkflow: false
+      applyToNginx: true
+      tpl: true
+      content: |
+        <!DOCTYPE html>
+        <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <link rel="stylesheet" href="dist/base.css" type="text/css" />
+          </head>
+          <body class="m-0">
+            <div class="py-4">
+              <div class="container">
+                <h1>Welcome to <strong>Materials Galaxy</strong>! powered by STFC Cloud CAPE</h1>
+              </div>
+                <br>
+                <div class="container">
+                <p>
+                  Materials Galaxy provides access to tools for tackling computational challenges in muon spectroscopy and X-ray absorption spectroscopy.
+                </p>
+                <p>
+                  Materials Galaxy is based on the Galaxy framework, which guarantees simple access, easy extension, 
+                  flexible adaption to personal and security needs, and sophisticated analyses independent of command-line knowledge.
+                </p>
+              </div>
+              <div class="container">
+                <h2>New to Materials Galaxy?</h2>
+                <p>Take an interactive tour:
+                  <a target="_parent" href="../tours/core.galaxy_ui" class="btn btn-secondary btn-sm">Galaxy UI</a>
+                  <a target="_parent" href="../tours/core.history" class="btn btn-secondary btn-sm">History</a>
+                   <a target="_parent" href="../tours/core.scratchbook" class="btn btn-secondary btn-sm">Scratchbook</a>
+                </p>
+                <p>
+                  Or try these tutorials:
+                </p>
+                <ul>
+                  <li>
+                    <a href="https://training.galaxyproject.org/training-material/topics/introduction/tutorials/galaxy-intro-101-everyone/tutorial.html">Galaxy 101 for everyone</a>
+                  </li>
+                  <li>
+                    <a href="https://training.galaxyproject.org/training-material/topics/materials-science/tutorials/muon-stopping-sites-muairss-uep/tutorial.html"> Finding muon stopping sites with PyMuonSuite </a>
+                  </li>
+                  <li>
+                    Modelling spin dynamics with MuSpinSim (coming soon)
+                  </li>
+                </ul>
+              <p></p>
+              </div>
+              <div class="container">
+                <h2>Reproducibility &amp; Transparency</h2>
+                <p>
+                  The history is the foundation of reproducibility and transparency in Galaxy. 
+                  It captures inputs, parameters, and versions of the used tools. It can be shared with everyone, even outside the Galaxy framework.
+                </p>
+                <p>
+                  Galaxy provides also a powerful workflow system.
+                  Workflows can be created by extraction of workflows from histories or from scratch with drag-and-drop. 
+                  They are downloadable and shareable with everyone, no vendor lock-in.
+                  Click 'All Workflows' in the tool panel to see the available public workflows or build your own.
+                </p>    
+              </div>
+              <div class="container">
+                <h2>Contact Us</h2>
+                <p>
+                  Materials Galaxy is run by members of the 
+                  <a target="_blank" class="reference" href="https://muon-spectroscopy-computational-project.github.io">Muon Spectroscopy Computational Project</a>.
+                  You can contact us in the
+                  <a target="_blank" class="reference" href="https://matrix.to/#/#galaxyproject_materials-science:matrix.org">Galaxy for Materials Science Matrix channel</a>.
+                  We have expertise in applying computational muon science tools (including those present in Materials Galaxy) to complex physical systems. 
+                  We are happy to provide support with learning Galaxy, learning our muon and XAS science tools, and applying these tools to particular physical systems.
+                </p>
+              </div>
+              <div class="container">
+                <h2>Acknowledgment</h2>
+                <p>
+                  We are aiming to maintain high competency and provide high-quality data analysis services to all our Galaxy users.
+                </p>
+                <p>      
+                  Therefore, we request that you acknowledge this service by including the members of the Muon Spectroscopy Computational Project as co-authors 
+                  if they have made a significant intellectual and/or organizational contribution to the work described 
+                  (conceptualization, design, data analysis, data interpretation and/or input into drafting, revising or writing any portion of the manuscript).
+                </p>
+                <p>
+                  Individuals who have contributed to the project, but whose contributions do not rise to the level justifying authorship, 
+                  can be recognized in the acknowledgements section of the manuscript as follows:
+                </p>
+                <blockquote>
+                <p>
+                  <em>
+                    The authors acknowledge the support of the Muon Spectroscopy Computational Project: 
+                    Person X and Person Z, Science and Technology Facilities Council, UK Research and Innovation, 
+                    co-funded by the Ada Lovelace Centre, Scientific Computing Department, STFC, UKRI, 
+                    and Horizon Europe grant 101057388 (EuroScienceGateway).
+                  </em>
+                </p>
+                </blockquote>                
+                <p>
+                  Additional funding of projects as well as the provision of material expenses is welcome to support our growing Galaxy community. Please also cite the 
+                  <a target="_blank" class="reference" href="https://doi.org/10.1093/nar/gkac247">main Galaxy publication</a>.
+                </p>
+              </div>
+            </div>
+            <hr>
+            <div class="container">
+              <footer>
+                <p>
+                  <a target="_blank" class="reference" href="http://galaxyproject.org/">
+                  Galaxy</a> is an open platform for supporting data intensive
+                  research. Galaxy is developed by <a target="_blank" class="reference" href="https://galaxyproject.org/galaxy-team/">The Galaxy Team</a>
+                  with the support of  <a target="_blank" class="reference" href="https://github.com/galaxyproject/galaxy/blob/dev/CONTRIBUTORS.md">many contributors</a>.
+                </p>
+                <p>
+                  This site is maintained by members of the
+                  <a target="_blank" class="reference" href="https://muon-spectroscopy-computational-project.github.io">Muon Spectroscopy Computational Project</a> (MSCP) 
+                  within the 
+                  <a target="_blank" class="reference" href="http://stfc.ac.uk">Science and Technology Facilities Council</a> (STFC), UK Research and Innovation, 
+                  with financial support from the
+                  <a target="_blank" class="reference" href="https://www.infraportal.org.uk/infrastructure/ada-lovelace-centre">Ada Lovelace Centre</a>
+                  and Horizon Europe grant 101057388
+                  (<a target="_blank" class="reference" href="https://elixir-italy.org/project/eurosciencegateway/">EuroScienceGateway</a>).
+                  Additional support for the MSCP comes from STFC
+                  <!--<a target="_blank" class="reference" href="https://www.isis.stfc.ac.uk">ISIS Neutron and Muon Source</a>-->
+                  and the
+                  <a target="_blank" class="reference" href="https://www.software.ac.uk">Software Sustainability Institute</a>.
+                </p>    
+                  <div id="version-footer" height="40px" style="text-align:center;line-height:40px;height:40px;">
+                    <p class="text-center"><small>Galaxy version v{{ .Chart.AppVersion }}, Helm Chart v{{ .Chart.Version }}</small></p>
+                  </div>
+              </footer>
+            </div>
+          </body>
+        </html>
+
+  # disable influxdb database - used by metrics scraper tool
+  influxdb:
+    enabled: false
+
+  # turn off file transfering for now
+  tusd:
+    enabled: false
+
+  # we need a message queue so galaxy components can talk to each other
+  rabbitmq:
+    enabled: true
+    deploy: false
+    persistence:
+      storageClassName: longhorn
+
+  # don't need cvmfs since its only needed to copy in default galaxy tools/reference data
+  cvmfs:
+    deploy: false
+
+  # don't need s3 since we don't use that to copy in galaxy tools/reference data
+  s3csi:
+    deploy: false
+
+oauth2-proxy:
+  # Oauth client configuration specifics
+  extraArgs:
+    upstream: "http://{{.Release.Name}}-nginx"
+    redirect-url: "https://galaxy.example.com/oauth2/callback"
+    email-domain: "*"
+    provider: oidc
+    provider-display-name: "iris-iam"
+    oidc-issuer-url:  "https://iris-iam.stfc.ac.uk/"
+    skip-provider-button: "true"
+    pass-authorization-header: "true" 
+    set-authorization-header: "true"
+    set-xauthrequest: "true"
+    cookie-secure: "true"
+    pass-user-headers: "true"
+    auth-logging: "true"
+    cookie-refresh: 15m
+
+  ingress:
+    enabled: false    

--- a/clusters/staging/worker/apps.yaml
+++ b/clusters/staging/worker/apps.yaml
@@ -62,6 +62,17 @@ spec:
             namespace: victoria-metrics
             valuesFile: ../../../clusters/staging/worker/vicmet-values.yaml
 
+          - name: longhorn
+            chartName: longhorn
+            namespace: longhorn-system
+            valuesFile: ../../../clusters/staging/worker/argocd-setup-values.yaml
+
+          - name: materials-galaxy
+            chartName: materials-galaxy
+            namespace: materials-galaxy
+            valuesFile: ../../../clusters/staging/worker/materials-galaxy-values.yaml
+            secretsFile: ../../../secrets/staging/worker/apps/materials-galaxy.yaml
+
 
   syncPolicy:
     # Don't remove everything if we remove the appset

--- a/clusters/staging/worker/argocd-setup-values.yaml
+++ b/clusters/staging/worker/argocd-setup-values.yaml
@@ -1,3 +1,10 @@
 argo-cd:
   global:
     domain: argocd.staging-worker.nubes.stfc.ac.uk
+  
+  longhorn:
+    ingress:
+      host: "longhorn.staging-worker.nubes.stfc.ac.uk"
+    persistence:
+      # can't be set for RWX
+      migratable: false

--- a/clusters/staging/worker/materials-galaxy-values.yaml
+++ b/clusters/staging/worker/materials-galaxy-values.yaml
@@ -1,0 +1,16 @@
+oauth2-proxy:
+
+
+  extraArgs:
+    redirect-url: "https://galaxy.staging-worker.nubes.stfc.ac.uk/oauth2/callback"
+
+galaxy:
+  ingress:
+    hosts:
+    - host: "galaxy.staging-worker.nubes.stfc.ac.uk"
+      paths:
+        - path: "/"
+    tls:
+    - hosts:
+        - "galaxy.staging-worker.nubes.stfc.ac.uk" 
+      secretName: galaxy-tls

--- a/secrets/dev/worker/apps/materials-galaxy.yaml
+++ b/secrets/dev/worker/apps/materials-galaxy.yaml
@@ -7,18 +7,17 @@ oauth2-proxy:
         #ENC[AES256_GCM,data:LwXfBvlJbFi7vQHigEt5T+CZZQ8myDrKD8oy93riwefugH78QRVSg82TLS0URQ==,iv:EKbiiTkqvbtQtz8pDu3LUwRXC6bZuKjNXczHSl5i0qo=,tag:tI+85K/8UNLCLdPNSkDy3w==,type:comment]
         cookieSecret: ENC[AES256_GCM,data:xW8wdHx14E3r+GlidP44ULSHPT3BFGuEn0lkFX2ejJaj2JCLOsJUzVbRj/s=,iv:beNa9VOmS0YAGw+bjetey9pD1nEzZ7T6SveoxvP15ps=,tag:IsKUoDu40+bbvcY5cMA5Ow==,type:str]
     authenticatedEmailsFile:
-        enabled: ENC[AES256_GCM,data:MhzWaw==,iv:SeWlVtxPEm90KJnIayvDIAuu+kN103hJSALxtUwnqCo=,tag:nXrVedMp6XJqaD+nEEnRlQ==,type:bool]
-        restricted_access: ENC[AES256_GCM,data:aDGTqeP3hs7d/68s9qgZom9OZIl2i5ppnr6eLmI9f9b+xTrmcJv/te2WfhxSN/J/UbQrXkJ4xJBB8X1g+IThD5BWT0yhZGK2J3pDyeXT63SRdkAljlC882EgTXE/QsIppI2nBalTpti7QtTd83NuICNxjWlY1ZyJxR1D/2KrvzjxtbLE0ekfrK/3ZPgVmv9G8O/YzVssR+NZMSxgKiSHH+w94MVlmG7wUA3rhtJTUJPlZrh3+aSdlzwlC0OnvkSJe0sCkj7GC8aQwOH5rd8fSvJRZjbVV9M0mafgp/U4J0BCljauB9vFHIbWuXZYwMd8S+lV5mY8K9OuoP0RY+yZ+IbvzbaupN6ETISd4q7bcO/bw0GOgauQgZBjxncT/I1nsgFHQPBjK0L+prrc5+EQu6VtINOhpZZtAkgci26W2EYySLvDXmDWOAgldV8qLTG5HwVbl/9fxMw9VAFZK8U+HDCUk4cCN4LTIEIGMWZZOKJUvIrErdo17hawXrsAMnj+2E8tXfs6nfzMsAbX3ulB2UbUiwy70CxK+PwIhAQu6DFLyB4p8wCKfNcBrzpnPzg=,iv:lcWEwGWE64/id5IylheT05gnQ+GR9EK/4hCweF5qw7U=,tag:Ca/L7uscwnK63Pqn4SVevg==,type:str]
+        enabled: ENC[AES256_GCM,data:GNa/vPc=,iv:nINd5U1vzSMLUEkS6ltdvk2ew4odb267f3kElToiPm0=,tag:++KJFcsbHVKUzNBB1LLwXg==,type:bool]
+    extraArgs:
+        allowed-group: ENC[AES256_GCM,data:aSFt8DLEbt9YDYEESJuG,iv:7dc+gsSKH1FBaddSIISkMN9WWIiKT9jSsNMdLQIlEEs=,tag:DTgbpAkegbXJk9+B/QvSrg==,type:str]
 galaxy:
     postgresql:
-        #ENC[AES256_GCM,data:po075c487X1yo0LYCC6bvQ8KZGxHKCWbzrs0cbBQ/hQ8xk/qqnIHxn1U0JlffZsja1ugSdOSXQ==,iv:gmHObqLyl8vZB/kGxucRsmQF8LLckAa3aH92dB5c+Io=,tag:f5vg5uyL6lD/R/6YELm5vA==,type:comment]
-        #ENC[AES256_GCM,data:IqJbntSQjo/Knm5XdTNbx40yN08Jls8USxbqm++DOL9PwHCs0pd0U+5qJ9+4BI487rkr4802Ag==,iv:KhdZNn17g4P6uhka01ckquTXMBBGqNVLgA0le8CTudQ=,tag:9HxCDFpeLGVROjDNd5dHzA==,type:comment]
         galaxyDatabasePassword: ENC[AES256_GCM,data:fKEsaLNbFTpyhulzqzI6uw==,iv:FHTRoyGxJ93zrceQ/tDmuHVfIWWwdvZrQ2U0J4Km5eM=,tag:eTvP6TmUJT6EXWwN6vSTeA==,type:str]
     configs:
         galaxy.yml:
             galaxy:
                 #ENC[AES256_GCM,data:qSqE6O4GY2UlkXsH5Hd3WlkEKcxz/M5VNG+SHcP8JLoL2Q==,iv:fa+kDALeDOU4/9/cv6/QZzzsKOxifxnHn3fzlEyeT70=,tag:nHG2kNtwKkBr+noGvhUShQ==,type:comment]
-                admin_users: ENC[AES256_GCM,data:V6KQxA1CserdVtInwTjwXeHkDfAsaH+fs5Ya6kzhDpbNs38LI8lm0QdKEG4fFP7nnflxb7OugWR/vMVkRbX3I+IXDNu37k1dYxl4ah0GKtqyWzcwB+OgxWyo5qdBBa2JfRyJ1J8c8dtPfmV3RU8z,iv:RL3nMFWd3WmLUU26hTcyYVwbMQvVmuwDg+nBE4hD2Xo=,tag:1qrCWzny++8mBfQuf0AYZQ==,type:str]
+                admin_users: ENC[AES256_GCM,data:dcLlzoqbdTOq2yqkQuObDd8d29CceB0/OShpEm80YUG2dbWOJyg7vmbv3TZ5fPd6N6gPB8gnZg==,iv:KBSGMVo3NJuNVaNwsZPGu5VTw3Lpwz0d3ZJpdemEi74=,tag:X8jKIgoUGdA3gYY2qthX+A==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -79,8 +78,8 @@ sops:
             Wm52YXBEbEdPa0pDMTRpZkQ2cUVSVDAKpMP0ksJfs1V9n05v9bEMrZpSnKpHpzuo
             O6LRx3uxF4r8BvDLuUqSJPgUsFgYwgxDtgJ+/RnS8Odoab+4E8rK0Q==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-11-21T16:28:45Z"
-    mac: ENC[AES256_GCM,data:JWiWHT4pe64O+UYd1HedNt1Rlp4lHdKuyZz/HBLs6a59ICk0TSI9rlt7nTSmZbzPaiRPp6SOJQRn7nrL4OH9KMwhey4cX4SmotGAQrsdcRpy6zeorXQZpnx/0Qu1jGaXm5afcRsMg3bY8TTz+roiJdIuQbM4C9xNcSqevVMge/o=,iv:iXzbwEONxzeDFjKNKqwFgfH2+OORLp083KYgTaHFCYw=,tag:1IsUg/kf6bXAlFozy0YfeA==,type:str]
+    lastmodified: "2024-11-21T18:21:39Z"
+    mac: ENC[AES256_GCM,data:1R2dykqxa0kU6e9iTOuoT1zGeaj5BjJ1zbbgKgQ6gwVYh7nPS6laJ79PJZNEkOfZnx6dHTCpeDDhcv1NPg0DJvQMgdCTqyswbxeyCPMvQw8VT3HIMw98ka4EsqFdDnW5NU8aaVtHG3x/k4yZC/hTG2p8cCn9USbDWgykUk5Or6g=,iv:04zMfdfwqHbgfG4eoG/U+qKEGposDQXhq/z92tuqTTI=,tag:ebCWKk05Wmukw+jXNegD1g==,type:str]
     pgp: []
     unencrypted_regex: ^(apiVersion|metadata|kind|type)$
     version: 3.8.1

--- a/secrets/staging/worker/apps/.sops.yaml
+++ b/secrets/staging/worker/apps/.sops.yaml
@@ -1,0 +1,10 @@
+creation_rules:
+  - unencrypted_regex: "^(apiVersion|metadata|kind|type)$"
+    key_groups:
+      - age:
+          # Staging Management Cluster - ArgoCD Access Key (Temporary)
+          - age1kkmt80g0cq4uud8gtxwa9p9y4l9nwa2mk8rlqp29sgvkku99evesc0gfsl
+
+          # Access Keys
+          # Staging Access Key
+          - age1hsll27prywydttq7dtnqtdnu2jpr8zhaulx00l7n4pqmxkhr55vspqmj6l

--- a/secrets/staging/worker/apps/materials-galaxy.yaml
+++ b/secrets/staging/worker/apps/materials-galaxy.yaml
@@ -1,0 +1,50 @@
+oauth2-proxy:
+    #ENC[AES256_GCM,data:L0+0BlMVQyKVFKXJ0hvBIkDKq8rRLhIhbsdX7g==,iv:1OiAOTBHUymtf9YA/t4DqCjqH6IWw6LCeMGFWqXN4Q0=,tag:CMnHDLKpZRNW6tdZ3z6EZg==,type:comment]
+    config:
+        clientID: ENC[AES256_GCM,data:1JoT/jJg0tJgKHJbuVlY0bDDS7hOua8EIJvvlOCHYM2HccPa,iv:OrIwG5+ahyzlFio4/6XjrXuKN8bn9hpb61E2FFtRs0k=,tag:dWHWWlrRkV0sgdDGWkG0Eg==,type:str]
+        clientSecret: ENC[AES256_GCM,data:wTdMkccGQAKSeJV6+ID6itA3rPMBEJMO0KtGXUV73LunsdSxY0QeEAm71tKe2VmUk6s20Dxj2TPyM8258+AjCqYGnks97fXrNPdoNhgMZurLNzv5dLL8,iv:DVpyfmGWoKq0PPvt+X1DS1WM7xiwwabi67mu66q9eew=,tag:xY9NWn8+0OHMc12bRZtrjg==,type:str]
+        #ENC[AES256_GCM,data:3kgXe3Q6z4cv/3mjsnudAIjt2lPW+mBlUI0ZzAuOXAZS6yBnHDxdd1+eQxCNDMU=,iv:cw0wbEnLRyF/GHragzfx5aDGmN5+2zcCDcwYBfBL34I=,tag:MzVu334OR0phqp2nzp0mtw==,type:comment]
+        #ENC[AES256_GCM,data:d5GzJ+y0z2p+LfpLv1Cy/RxBBaAc8MBDd6GsBUj4wHNT/idkuoxwUhb5lndveQ==,iv:aaUNSkj3dYjlb5rEa8SGvM9hAjSu+kEgCxUGklL/R1Y=,tag:YS666eArKdCsN14QeCZFCw==,type:comment]
+        cookieSecret: ENC[AES256_GCM,data:M2/eWCIpQQz2EzmJrAte6gg6p3Qr2bs98maFp8tA8trlpfGB4o4P/Hx8tpI=,iv:lah/gSLGMYshYbrVCmph5oHSpIywEvXuK/YKAlgVbpo=,tag:oQE/cdR0G6XEatZ+aM4sIg==,type:str]
+    authenticatedEmailsFile:
+        enabled: ENC[AES256_GCM,data:qIqvDw==,iv:LeGHKSMcSZdOVyHfd6r59WDqNd2D+93NsKgj1z51qjg=,tag:b2/mNgvlXQX+f6qNYkE+mg==,type:bool]
+        restricted_access: ENC[AES256_GCM,data:NrDzTIl49CmASb4e9jg2U+h4hOfGykbZ4aU2AxySp+kTmkW6AHZmwkvPGBN4+4VIeGneGygEBJB/dc7PXhgy2rOKGlDKwpMltYEDEm6fCoto/0ennXykOYMxduh/LhpsnSiAHClCw+sEu3K1RK4AKAatXcDQuKwLSGVuU72t+1Qci+16DufW0XqcEyM+8OaxipFJ1t9Bjh0taiZPtWmI0nO48rqlFNirikyWrPzGRMNaHQOpCGjYAzMKg4S/BYQlH3nre5vN78Z4VWe1D+Bj+r6yqAPt9tScsOtG3imimK/sMmYM2pYRYyQ1YGUlCfYc4aQ+UMo9pTE4+B1oqxLPSeMIoiIZv5xLquew6YpVJA08lPAlTCgY5EXO2/EtFlf86+2gvukQcsUgjET4bU4KDI8yDMjQdrctZ6G9YPSD1YlGz/69Uuy9Ue0cs05Imq54klrIHzAIq59htKWvMWTvHjuA5/AV8TpXk5mfLpYPvq8j4cvUSh7QAs1kHMOgor3tHcbvm9ceBdbt+XrjEhcOPRix8h5VIw4b0E5QLBsxQhhNwTQZX4IXIDJNG7Ml6Ms=,iv:o0B645f+c4pb9WP0JVoRCxeTG2dKp+hswgfDnGML+dw=,tag:/1uIWdvTWFLwULBK0CyHEA==,type:str]
+galaxy:
+    postgresql:
+        #ENC[AES256_GCM,data:C6G/oOihT6OZzurVAOfdrYrBFwbYOhScMQhmSx3JlDMwBFsfowd0/nvtfb3G1RG4+Uy+Je3Z+w==,iv:DwZgEQylA7/pJfqXavbNgSnHTELnDOnJbpR+eJPW0W8=,tag:ar221KT+M9rl3tZmJ1QsTg==,type:comment]
+        #ENC[AES256_GCM,data:SDYakjDNEHEPFePuJgiCLVDSLAP+KyJO6k5NLz/m7zMkRTzJ5LGYZPnEDRAA6LAXRTURj+PC,iv:99C1gL3hXLwCdOpr8J9R1ltY6wUV+rsUJixp6dcuQ4E=,tag:Boac1FItOr5kqpOmi/YT9w==,type:comment]
+        galaxyDatabasePassword: ENC[AES256_GCM,data:1YNo9PGIMusPCef/h4Li+NTDXrWBc/c2,iv:FTeXgPxuSy98y6joBNQJIeejeEwiRVoec2wquTozqYU=,tag:ocXYbijzosI9DsYPGjjx+A==,type:str]
+    configs:
+        galaxy.yml:
+            galaxy:
+                #ENC[AES256_GCM,data:0XlRvwe3gsk9JgeHOtKkHtEhTke5nbm+kj+hMYKxgHn2pQ==,iv:0kN3Dhllkf1Ye5xpD+U7W7lFiKj8UDc0VEGsTwKBMmw=,tag:ccmBVuxwwjlQgCovQeUYEQ==,type:comment]
+                admin_users: ENC[AES256_GCM,data:g0BrHrDByu/Ddm3LIpxCc1Kzn0FW+5Dg3IdudWLPW5Hm2j3C16lOtdwlps++2qCrl5eUcTvgEQXBSrQGnYrB7LqHJ8ByRW9KB2OkLQnScgfW+YUQAbkUgGn13Ki2HxLBv7OA+n93xpREDBbCZsaO,iv:J8VV7oSMAHZgksFt6KkPaAlQH/yfJru2Tj6pJuMalFI=,tag:SOAPAiGMe9FBVpA6Bf/DKQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1kkmt80g0cq4uud8gtxwa9p9y4l9nwa2mk8rlqp29sgvkku99evesc0gfsl
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDclJzS05VckVoTjVENlFm
+            OXFpOHYwaVVlZTJVc1p5aGZKL1dKV0UxRVVZCkgvK0p6OU5UYlpjb3M2UklSMU1v
+            eEN6K3VheGU3QTUyOUcvb05rc2M1MDgKLS0tIE96MGx1K0ZwREJQN21zSGp3b0F0
+            UGE0V2NhZGZhS1p6a2Y2dnFxeG5aUm8K1qLoQYZ28OJ5vaBtlV0bPu1sWkXlclWz
+            TMqwyQzn+JwQMIn5LFDihc1PVVeDtfwnT32J6UbAd9N1HcRtB7VZrg==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1hsll27prywydttq7dtnqtdnu2jpr8zhaulx00l7n4pqmxkhr55vspqmj6l
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvTmViT1YzclR6WDdFQlJF
+            R3luRG1rdG5PSDY2eDJtckpPME11MGFyY2djClFGSXgyVjdJRm9GRXA0T1hSN1hn
+            NEpoU2JlajJQcE81UzJQNnZlY0ZYQ2cKLS0tIG53OEYrYnlhOXRhZ2xXaTJwTXdP
+            b0hHM2R6OC9jcEJISjRkWm9DeDJPem8KMJJ9GUatHPTQpdNxLwwPIukv5CsgacDT
+            rakCn70+ih5ILl32qUQtsIyx6rvO5lQ4u56OXq0uVToCzeJHEuQz5Q==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2024-11-21T18:21:12Z"
+    mac: ENC[AES256_GCM,data:rssMAfdk/RjMYYqZHMUKAhY3XDxHAQXFJq2B1Tg3vtYMM4XBEstvZZoTCIMdIrHP59qrXpbIC34eA65GgzQENnedWGPfYbv7wDSa3kcpJrI9jDLV6HXGHvrhrN/rLXOikCbL7iTaogXdBj50VKLtRJbPr/FO0VkEwOdUrPgLSfI=,iv:yxM1gQoUrBJLfkz74THrR60J5Qi6QACXWs2gk12JDiQ=,tag:wbt/uj/fQBeAoJeVSaj4gw==,type:str]
+    pgp: []
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.8.1


### PR DESCRIPTION
### Description:
Deploy galaxy to staging. This involves promoting galaxy chart to staging and configuring worker staging cluster to deploy an instance of the chart 

Additionally:
- make dev galaxy only accessible to cloud admins
- make staging galaxy accessible to interested parties e.g. PSDI  

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- If this is a hotfix for production, which needs to be deployed after merging
- If this requires manual work to deploy the PR, e.g. a parameter change
- If this has associated internal documentation too
-->

---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
