### PR TITLE
BUG: make vicmet cluster follow main

### DIFF
--- a/clusters/dev/vicmet/apps.yaml
+++ b/clusters/dev/vicmet/apps.yaml
@@ -10,7 +10,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/stfc/cloud-deployed-apps.git
-    targetRevision: update-secrets
+    targetRevision: main
     path: clusters/dev/vicmet
   syncPolicy:
     automated:
@@ -76,7 +76,7 @@ spec:
       project: default
       source:
         repoURL: "https://github.com/stfc/cloud-deployed-apps.git"
-        targetRevision: update-secrets
+        targetRevision: main
         path: "charts/dev/{{.chartName}}"
         helm:
           valueFiles:


### PR DESCRIPTION
leftover from using feature-branch that has been merged
