### PR TITLE
BUG: add nodelabels for enabling longhorn storage

### DIFF
--- a/clusters/staging/worker/infra-values.yaml
+++ b/clusters/staging/worker/infra-values.yaml
@@ -4,6 +4,13 @@ openstack-cluster:
     - name: default-md-0
       machineCount: 5
 
+  nodeGroupDefaults:
+    machineFlavor: l3.nano
+    nodeLabels:	
+      # we're running longhorn on this cluster
+      # set label so worker nodes can host longhorn volumes
+      longhorn.store.nodeselect/longhorn-storage-node: true
+
   addons:
     ingress:
       enabled: true


### PR DESCRIPTION
this wasn't turned on so longhorn was failing to spin up on staging worker
