### PR TITLE
BUG: modify the group interval and add null reciever

### DIFF
--- a/charts/dev/capi-infra/values.yaml
+++ b/charts/dev/capi-infra/values.yaml
@@ -187,11 +187,15 @@ openstack-cluster:
                   smtp_require_tls: false
 
                 route:
-                  receiver: "default-receiver"
-                  group_by: ["cluster", "service"]
-                  group_wait: 30m
-                  group_interval: 30m
-                  repeat_interval: 2d
+                  # we need a null reciever to workaround azimuth addon enforced defaults 
+                  # https://github.com/azimuth-cloud/capi-helm-charts/blob/main/charts/cluster-addons/templates/monitoring/kube-prometheus-stack.yaml#L41-L44
+                  receiver: "null"
+                  routes:
+                    receiver: "default-receiver"
+                    group_by: ["cluster", "service"]
+                    group_wait: 30m
+                    group_interval: 4h
+                    repeat_interval: 2d
 
                 inhibit_rules:
                   # mute warning/info alerts on same service if a critical alert is firing - less noise
@@ -221,6 +225,7 @@ openstack-cluster:
                         location: "Europe/London"
 
                 receivers:
+                  - name: "null"
                   - name: default-receiver
                     active_time_intervals:
                       - officehours


### PR DESCRIPTION
workaround for default group_by=[...] that azimuth adds

https://github.com/azimuth-cloud/capi-helm-charts/blob/main/charts/cluster-addons/templates/monitoring/kube-prometheus-stack.yaml#L41-L44

this means that alert-manager cluster addon forces no grouping by default on the top route  - which can't be overridden

adding "null" as the top route that doesn't have a receiver hopefully means that all alerts get forwarded to child route - which will group by service and cluster - so all alerts related to a service get sent in one email notification - it needs testing