### PR TITLE
BUG: Fix helm templating for ChatOps deployment

### DIFF
--- a/charts/dev/chatops/secrets-templates/secrets.yaml
+++ b/charts/dev/chatops/secrets-templates/secrets.yaml
@@ -1,8 +1,8 @@
-secrets: |
+secrets:
   slackBotToken: <>
   slackAppToken: <>
   githubToken: <>
-users:
-  - realName: <>
-    githubName: <>
-    slackID: <>
+  users:
+    - realName: foo
+      githubName: <>
+      slackID: <>

--- a/charts/dev/chatops/templates/cloud-chatops.yaml
+++ b/charts/dev/chatops/templates/cloud-chatops.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: {{ .Values.app }}
-        image: {{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag}}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag}}
         volumeMounts:
         - name: cloud-chatops-config
           mountPath: /usr/src/app/cloud_chatops/config
@@ -39,5 +39,3 @@ spec:
       - name: cloud-chatops-secrets
         secret:
           secretName: {{ .Values.env }}-cloud-chatops-secrets
-
-

--- a/charts/dev/chatops/templates/config-map.yaml
+++ b/charts/dev/chatops/templates/config-map.yaml
@@ -2,14 +2,13 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Values.env }}-cloud-chatops-config
-  namespace: cloud-chatops
+  namespace: {{ .Release.namespace }}
 data:
-  config.yml: |
-  ---
-  users:
-  {{ - range .Values.secrets.users }}
-    - real_name: {{ .name | quote }}
-      github_name: {{ .githubName | quote }}
-      slack_id: {{ .slackID | quote }}
-  {{ - end }}
-  repos: {{ toYaml .Values.repos | ndindent 2 }}
+  config.yml: |-
+    users:
+    {{- range .Values.secrets.users }}
+      - real_name: {{ .realName | quote }}
+        github_name: {{ .githubName | quote }}
+        slack_id: {{ .slackID | quote }}
+    {{- end }}
+    repos: {{ toYaml .Values.repos | nindent 6 }}

--- a/charts/dev/chatops/templates/secrets.yaml
+++ b/charts/dev/chatops/templates/secrets.yaml
@@ -2,9 +2,10 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.env }}-cloud-chatops-secrets
+  namespace: {{ .Release.namespace }}
 type: Opaque
-data:
-  secrets.yml: |
+stringData:
+  secrets.yml: |-
     SLACK_BOT_TOKEN: {{ .Values.secrets.slackBotToken }}
     SLACK_APP_TOKEN: {{ .Values.secrets.slackAppToken }}
     GITHUB_TOKEN: {{ .Values.secrets.githubToken }}

--- a/charts/dev/chatops/values.yaml
+++ b/charts/dev/chatops/values.yaml
@@ -2,8 +2,8 @@ env: dev
 app: cloud-chatops
 replicaCount: 3
 image:
-  repository: harbor.stfc.ac.uk/stfc-cloud-staging/cloud-chatops
-  tag: efc973a
+  repository: harbor.stfc.ac.uk/stfc-cloud/cloud-chatops
+  tag: 4.0.0
 repos:
   stfc:
     - cloud-deployed-apps

--- a/secrets/dev/worker/apps/chatops.yaml
+++ b/secrets/dev/worker/apps/chatops.yaml
@@ -2,10 +2,10 @@ secrets:
     slackBotToken: ENC[AES256_GCM,data:rcen7+DWh0jkaF3DWEOk80zkbwD07gUi1YRdTJmGYLWZrcDS9NTdGsmAJfHBf30B1B0FwZicNRHU,iv:Lh3zbUtA0BvAfpUH1p/0cUT0p+C+kxaKsKRTNhERugU=,tag:dwigiKrzDJ/DILCeeBSdwQ==,type:str]
     slackAppToken: ENC[AES256_GCM,data:T1cfCSaP6IlD1ySa1qdNcURHDRpqT4yhyN5aMb/+Wr1TYoz0teB5RN0CTAc0pMf651Kig8xhdP80AeNsMz859CP1HUi1fcJ77sQBRdIuhXpSAedMJgThOMHwLygzqbnJQQ==,iv:tpa8Oow2nPXb5EFRb+LeBPx3wJkDIOE4nUzR5jOeTE0=,tag:HSWtojZyMz8KQyzCYIiQHw==,type:str]
     githubToken: ENC[AES256_GCM,data:5qY4wKLbJq7LtOMCZS3VD6U20qR405CoAdKYTxAYA1DpImHTcN2/rVnbb4/t8raio7bCX+Hin5UkVvv4YrQx5GUdqtmKKR5CRvx/hGEe71W3xM7ePhlfOfRKzLe1,iv:20tso148S3xLvmHa4qWDDVI1+IyAXHMG8E7gBF+qyGo=,tag:+lEQC6vdUhH30bck+T/uNQ==,type:str]
-users:
-    - realName: ENC[AES256_GCM,data:4oD4x5+MliZ0cc1wgyo=,iv:I3RiblOpcotf+YjXbyAV0IC5QLMRl/4ymDapb9elFYc=,tag:RjRw8wBva0CQUR+cR6P/6g==,type:str]
-      githubName: ENC[AES256_GCM,data:Po8cBN+ZGJk=,iv:KqCfEW5J3i5v3UaVVh8nL4Gdqf5AfFk2bX6q8S6OEI0=,tag:xdjAxWRVQpYMQaNfExkwNw==,type:str]
-      slackID: ENC[AES256_GCM,data:n1Arqg0IRgsLQOM=,iv:4O1oIMNFcQ2u6emR51v2Hkx90SJ+XyUdGZEvgMb3dMU=,tag:Usom1Fbl1L/zNUrSFNn4gQ==,type:str]
+    users:
+        - realName: ENC[AES256_GCM,data:tzGAUPUyecHXcmQP7RA=,iv:Lv9w3Dc1WzWhK367KGWs75IVYZwT50256XQLGJKBVTw=,tag:Qs2NwtLeeJENGs/wf4UL+A==,type:str]
+          githubName: ENC[AES256_GCM,data:YnAQwTUMG3U=,iv:8zyXCvzBZXeZplHKZtFht1CyJavSHYjgiKbwzohYQHY=,tag:l13Zl7dqsT6bEdHT3b9TWA==,type:str]
+          slackID: ENC[AES256_GCM,data:hTZV4U/TroBEJvE=,iv:Ww2lhegysn3ws0VMN/4/Sg7RXRrQsreU9TeavOVAYfQ=,tag:fl9SYGvVluAlxa3cDKSbqQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -75,8 +75,8 @@ sops:
             L0ZhYnNSY1laTHpad0R3d3Vrcjdja2MKKjeANCkROxxJQwKBI8EAKBhXRU62OY1Y
             CUgYTpYVrcXxOqeWnVvbTUMhu3/Q8mtvHT4F6hLmxErlz0s42DBNvQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-12-09T11:35:54Z"
-    mac: ENC[AES256_GCM,data:WziY6V+ugXNSPBbBI2MB01tUx60Z98rftlhLFiLLmZi3zGVn6sI9vqLZhK9qLnfvJttCviclJR2WsOWNYV952ZwS2UJrpVIhc3/vQcQMKesKcjp6ioEybOYBBXbA3BfhQJO5RcjRYXuRMY3eOzQPtWGHxZVe+rzCMCLD7LgjiL0=,iv:wFnAr9dBLF1Kk9sL+z/vzUNuLlMYCK/SPT6dXh7q0d0=,tag:oC8SsKoU/Qi0zoexhcpEWQ==,type:str]
+    lastmodified: "2024-12-10T10:57:05Z"
+    mac: ENC[AES256_GCM,data:Xk57HhDM/wfHsyw5co0bU/CXhZEh+J1PbiaSgZHA/vGtQdWWPrsg/RVy24MYhxmOi6VTM4/ZSKCX4bPcG+STEvtY6hfvqv5Hnd5baoExjj928NP0w0S9WgiG+y9yw5bP865vSOUH3NgUlGyr0ehgau48jpHOiOnN5LnuPz1h5AI=,iv:ac99p8tp4OCv1l85b4C/cFPaKBkHf3qCcurK3QtlgVI=,tag:m6SSKaR32mS1wkIte1Eawg==,type:str]
     pgp: []
     unencrypted_regex: ^(apiVersion|metadata|kind|type)$
     version: 3.9.1


### PR DESCRIPTION
Includes Helm Templating bug fixes for ChatOps deployment. Also, changes container image from a dev image to a production image

### Description:

<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
