### PR TITLE
Edit chatops setup values

### DIFF
--- a/clusters/dev/cloud-chatops/apps.yaml
+++ b/clusters/dev/cloud-chatops/apps.yaml
@@ -10,7 +10,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/stfc/cloud-deployed-apps.git
-    targetRevision: main
+    targetRevision: dev-cloud-chatops
     path: clusters/dev/cloud-chatops
   syncPolicy:
     automated:

--- a/clusters/dev/cloud-chatops/apps.yaml
+++ b/clusters/dev/cloud-chatops/apps.yaml
@@ -40,23 +40,18 @@ spec:
             # so create one for each chart - even if its empty
 
             # argocd and all dependencies use the same file "argocd-setup-values.yaml"
-            valuesFile: ../../../clusters/dev/worker/argocd-setup-values.yaml
+            valuesFile: ../../../clusters/dev/cloud-chatops/argocd-setup-values.yaml
             namespace: argocd
 
           - name: "cert-manager"
             chartName: cert-manager
             namespace: cert-manager
-            valuesFile: ../../../clusters/dev/worker/argocd-setup-values.yaml
-
-          - name: longhorn
-            chartName: longhorn
-            namespace: longhorn-system
-            valuesFile: ../../../clusters/dev/worker/argocd-setup-values.yaml
+            valuesFile: ../../../clusters/dev/cloud-chatops/argocd-setup-values.yaml
 
           - name: chatops
             chartName: chatops
             namespace: chatops
-            secretsFile: ../../../secrets/dev/worker/apps/chatops.yaml
+            secretsFile: ../../../secrets/dev/cloud-chatops/apps/chatops.yaml
 
   syncPolicy:
     # Don't remove everything if we remove the appset

--- a/clusters/dev/cloud-chatops/argocd-setup-values.yaml
+++ b/clusters/dev/cloud-chatops/argocd-setup-values.yaml
@@ -1,0 +1,3 @@
+argo-cd:
+  global:
+    domain: argocd.dev-cloud-chatops.nubes.stfc.ac.uk

--- a/clusters/dev/cloud-chatops/infra-values.yaml
+++ b/clusters/dev/cloud-chatops/infra-values.yaml
@@ -17,4 +17,10 @@ openstack-cluster:
 # here we define an nginx ingress controller service
   addons:
     ingress:
-      enabled: false
+      enabled: true
+      nginx:
+        release:
+          values:
+            controller:
+              service:
+                loadBalancerIP: "130.246.211.56"


### PR DESCRIPTION
### Description:

Editing setup values from original PR to setup apps. The values paths were not changes from worker to cloud-chatops cluster.
Also, adding set up values for argocd domain to access the UI

---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
