### PR TITLE
Bump capi-infra chart to 0.12.2

### DIFF
--- a/charts/dev/capi-infra/Chart.yaml
+++ b/charts/dev/capi-infra/Chart.yaml
@@ -4,4 +4,4 @@ version: 1.3.0
 dependencies:
   - repository: https://azimuth-cloud.github.io/capi-helm-charts
     name: openstack-cluster
-    version: 0.11.2
+    version: 0.12.2

--- a/charts/dev/capi-infra/values.yaml
+++ b/charts/dev/capi-infra/values.yaml
@@ -1,6 +1,6 @@
 openstack-cluster:
-  kubernetesVersion: "1.30.6"
-  machineImage: "capi-ubuntu-2204-kube-v1.30.6-2024-11-15"
+  kubernetesVersion: "1.30.8"
+  machineImage: "capi-ubuntu-2204-kube-v1.30.8-2025-01-02"
 
   # The PEM-encoded CA certificate for openstack.stfc.ac.uk
   # this expires 2023-12-05T23:59:59Z (UTC)

--- a/charts/dev/cluster-api-addon-provider/Chart.yaml
+++ b/charts/dev/cluster-api-addon-provider/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cluster-api-addon-provider
-version: 1.0.0
+version: 1.2.0 
 dependencies:
   - repository: https://azimuth-cloud.github.io/cluster-api-addon-provider
     name: cluster-api-addon-provider
-    version: 0.7.1
+    version: 0.7.2


### PR DESCRIPTION
only affects dev

Bump capi-infra chart to 0.12.2
bump capi-addon provider to 0.7.2

bump dev clusters to use 1.30.8 k8s image
