### PR TITLE
MAINT: Move cluster App of Apps to feature branch

### DIFF
--- a/clusters/dev/cloud-chatops/apps.yaml
+++ b/clusters/dev/cloud-chatops/apps.yaml
@@ -65,7 +65,7 @@ spec:
       project: default
       source:
         repoURL: "https://github.com/stfc/cloud-deployed-apps.git"
-        targetRevision: main
+        targetRevision: dev-cloud-chatops
         path: "charts/dev/{{.chartName}}"
         helm:
           valueFiles:


### PR DESCRIPTION
### Description:

Moving ChatOps App of Apps to feature branch. Missed this in the previous PR.

---

### Submitter:

Have you:

* [ ] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
