### PR TITLE
Promote chatops to staging

### DIFF
--- a/charts/dev/chatops/Chart.yaml
+++ b/charts/dev/chatops/Chart.yaml
@@ -3,4 +3,4 @@ name: cloud-chatops
 description: Cloud ChatOps helm chart
 type: application
 version: 0.1.0
-appVersion: "5.0.0"
+appVersion: "5.0.1"

--- a/charts/dev/chatops/Chart.yaml
+++ b/charts/dev/chatops/Chart.yaml
@@ -3,4 +3,4 @@ name: cloud-chatops
 description: Cloud ChatOps helm chart
 type: application
 version: 0.1.0
-appVersion: "5.0.1"
+appVersion: "5.0.2"

--- a/charts/dev/chatops/values.yaml
+++ b/charts/dev/chatops/values.yaml
@@ -1,28 +1,6 @@
 env: dev
 app: cloud-chatops
-replicaCount: 3
+replicaCount: 1
 image:
   repository: harbor.stfc.ac.uk/stfc-cloud/cloud-chatops
   tag: 5.0.2
-repos:
-  stfc:
-    - cloud-deployed-apps
-    - st2-cloud-pack
-    - cloud-grafana-dashboards
-    - cloud-pe-jupyterhub
-    - cloud-ops-tools
-    - cloud-docker-images
-    - cloud-capi-values
-    - cloud-image-builders
-    - cloud-docs
-    - cloud-openstack-horizon
-    - ansible-harbor
-    - terraform-openstack
-    - cloud-rundeck-jobs
-    - openstack-guide
-    - ansible-jupyter
-    - SCD-Openstack-Utils
-    - check-version-action
-    - cloud-helm-charts
-    - openstack-query-library
-channel: C07QX38AR5W

--- a/charts/dev/chatops/values.yaml
+++ b/charts/dev/chatops/values.yaml
@@ -1,9 +1,9 @@
 env: dev
 app: cloud-chatops
-replicaCount: 3
+replicaCount: 0
 image:
-  repository: harbor.stfc.ac.uk/stfc-cloud/cloud-chatops
-  tag: 5.0.1
+  repository: harbor.stfc.ac.uk/stfc-cloud-staging/cloud-chatops
+  tag: some-sha
 repos:
   stfc:
     - cloud-deployed-apps
@@ -25,4 +25,4 @@ repos:
     - check-version-action
     - cloud-helm-charts
     - openstack-query-library
-channel: C03RT2F6WHZ
+channel: C07QX38AR5W

--- a/charts/dev/chatops/values.yaml
+++ b/charts/dev/chatops/values.yaml
@@ -2,8 +2,8 @@ env: dev
 app: cloud-chatops
 replicaCount: 3
 image:
-  repository: harbor.stfc.ac.uk/stfc-cloud-staging/cloud-chatops
-  tag: some-sha
+  repository: harbor.stfc.ac.uk/stfc-cloud/cloud-chatops
+  tag: 5.0.2
 repos:
   stfc:
     - cloud-deployed-apps

--- a/charts/dev/chatops/values.yaml
+++ b/charts/dev/chatops/values.yaml
@@ -1,6 +1,6 @@
 env: dev
 app: cloud-chatops
-replicaCount: 0
+replicaCount: 3
 image:
   repository: harbor.stfc.ac.uk/stfc-cloud-staging/cloud-chatops
   tag: some-sha

--- a/charts/staging/chatops/Chart.yaml
+++ b/charts/staging/chatops/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: cloud-chatops
+description: Cloud ChatOps helm chart
+type: application
+version: 0.1.0
+appVersion: "5.0.1"

--- a/charts/staging/chatops/Chart.yaml
+++ b/charts/staging/chatops/Chart.yaml
@@ -3,4 +3,4 @@ name: cloud-chatops
 description: Cloud ChatOps helm chart
 type: application
 version: 0.1.0
-appVersion: "5.0.1"
+appVersion: "5.0.2"

--- a/charts/staging/chatops/secrets-templates/secrets.yaml
+++ b/charts/staging/chatops/secrets-templates/secrets.yaml
@@ -1,0 +1,8 @@
+secrets:
+  slackBotToken: <>
+  slackAppToken: <>
+  githubToken: <>
+  users:
+    - realName: foo
+      githubName: <>
+      slackID: <>

--- a/charts/staging/chatops/templates/cloud-chatops.yaml
+++ b/charts/staging/chatops/templates/cloud-chatops.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.env }}-{{ .Values.app }}
+  labels:
+    app: {{ .Values.app }}
+  namespace: {{ .Release.namespace }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: {{ .Values.app }}
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: {{ .Values.app }}
+
+    spec:
+      containers:
+      - name: {{ .Values.app }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag}}
+        env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        volumeMounts:
+        - name: cloud-chatops-config
+          mountPath: /usr/src/app/cloud_chatops/config
+          readOnly: true
+        - name: cloud-chatops-secrets
+          mountPath: /usr/src/app/cloud_chatops/secrets
+          readOnly: true
+
+      volumes:
+      - name: cloud-chatops-config
+        configMap:
+          name: {{ .Values.env }}-cloud-chatops-config
+          items:
+          - key: "config.yml"
+            path: "config.yml"
+      - name: cloud-chatops-secrets
+        secret:
+          secretName: {{ .Values.env }}-cloud-chatops-secrets

--- a/charts/staging/chatops/templates/config-map.yaml
+++ b/charts/staging/chatops/templates/config-map.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.env }}-cloud-chatops-config
+  namespace: {{ .Release.namespace }}
+data:
+  config.yml: |-
+    users:
+    {{- range .Values.secrets.users }}
+      - real_name: {{ .realName | quote }}
+        github_name: {{ .githubName | quote }}
+        slack_id: {{ .slackID | quote }}
+    {{- end }}
+    repos: {{ toYaml .Values.repos | nindent 6 }}
+    channel: {{ .Values.channel }}

--- a/charts/staging/chatops/templates/secrets.yaml
+++ b/charts/staging/chatops/templates/secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.env }}-cloud-chatops-secrets
+  namespace: {{ .Release.namespace }}
+type: Opaque
+stringData:
+  secrets.yml: |-
+    SLACK_BOT_TOKEN: {{ .Values.secrets.slackBotToken }}
+    SLACK_APP_TOKEN: {{ .Values.secrets.slackAppToken }}
+    GITHUB_TOKEN: {{ .Values.secrets.githubToken }}

--- a/charts/staging/chatops/values.yaml
+++ b/charts/staging/chatops/values.yaml
@@ -4,25 +4,3 @@ replicaCount: 1
 image:
   repository: harbor.stfc.ac.uk/stfc-cloud/cloud-chatops
   tag: 5.0.1
-repos:
-  stfc:
-    - cloud-deployed-apps
-    - st2-cloud-pack
-    - cloud-grafana-dashboards
-    - cloud-pe-jupyterhub
-    - cloud-ops-tools
-    - cloud-docker-images
-    - cloud-capi-values
-    - cloud-image-builders
-    - cloud-docs
-    - cloud-openstack-horizon
-    - ansible-harbor
-    - terraform-openstack
-    - cloud-rundeck-jobs
-    - openstack-guide
-    - ansible-jupyter
-    - SCD-Openstack-Utils
-    - check-version-action
-    - cloud-helm-charts
-    - openstack-query-library
-channel: C03RT2F6WHZ

--- a/charts/staging/chatops/values.yaml
+++ b/charts/staging/chatops/values.yaml
@@ -1,0 +1,28 @@
+env: staging
+app: cloud-chatops
+replicaCount: 1
+image:
+  repository: harbor.stfc.ac.uk/stfc-cloud/cloud-chatops
+  tag: 5.0.1
+repos:
+  stfc:
+    - cloud-deployed-apps
+    - st2-cloud-pack
+    - cloud-grafana-dashboards
+    - cloud-pe-jupyterhub
+    - cloud-ops-tools
+    - cloud-docker-images
+    - cloud-capi-values
+    - cloud-image-builders
+    - cloud-docs
+    - cloud-openstack-horizon
+    - ansible-harbor
+    - terraform-openstack
+    - cloud-rundeck-jobs
+    - openstack-guide
+    - ansible-jupyter
+    - SCD-Openstack-Utils
+    - check-version-action
+    - cloud-helm-charts
+    - openstack-query-library
+channel: C03RT2F6WHZ

--- a/charts/staging/chatops/values.yaml
+++ b/charts/staging/chatops/values.yaml
@@ -3,4 +3,4 @@ app: cloud-chatops
 replicaCount: 1
 image:
   repository: harbor.stfc.ac.uk/stfc-cloud/cloud-chatops
-  tag: 5.0.1
+  tag: 5.0.2

--- a/clusters/dev/cloud-chatops/apps.yaml
+++ b/clusters/dev/cloud-chatops/apps.yaml
@@ -48,10 +48,10 @@ spec:
             namespace: cert-manager
             valuesFile: ../../../clusters/dev/cloud-chatops/argocd-setup-values.yaml
 
-          - name: chatops
-            chartName: chatops
-            namespace: chatops
-            secretsFile: ../../../secrets/dev/cloud-chatops/apps/chatops.yaml
+          # - name: chatops
+          #   chartName: chatops
+          #   namespace: chatops
+          #   secretsFile: ../../../secrets/dev/cloud-chatops/apps/chatops.yaml
 
   syncPolicy:
     # Don't remove everything if we remove the appset

--- a/clusters/dev/cloud-chatops/apps.yaml
+++ b/clusters/dev/cloud-chatops/apps.yaml
@@ -52,6 +52,7 @@ spec:
           #   chartName: chatops
           #   namespace: chatops
           #   secretsFile: ../../../secrets/dev/cloud-chatops/apps/chatops.yaml
+          #   valuesFile: ../../../clusters/dev/cloud-chatops/chatops-values.yaml
 
   syncPolicy:
     # Don't remove everything if we remove the appset

--- a/clusters/dev/cloud-chatops/chatops-values.yaml
+++ b/clusters/dev/cloud-chatops/chatops-values.yaml
@@ -1,0 +1,22 @@
+repos:
+  stfc:
+    - cloud-deployed-apps
+    - st2-cloud-pack
+    - cloud-grafana-dashboards
+    - cloud-pe-jupyterhub
+    - cloud-ops-tools
+    - cloud-docker-images
+    - cloud-capi-values
+    - cloud-image-builders
+    - cloud-docs
+    - cloud-openstack-horizon
+    - ansible-harbor
+    - terraform-openstack
+    - cloud-rundeck-jobs
+    - openstack-guide
+    - ansible-jupyter
+    - SCD-Openstack-Utils
+    - check-version-action
+    - cloud-helm-charts
+    - openstack-query-library
+channel: C07QX38AR5W

--- a/clusters/staging/worker/apps.yaml
+++ b/clusters/staging/worker/apps.yaml
@@ -77,6 +77,7 @@ spec:
             chartName: chatops
             namespace: chatops
             secretsFile: ../../../secrets/staging/worker/apps/chatops.yaml
+            valuesFile: ../../../clusters/staging/worker/chatops-values.yaml
 
 
   syncPolicy:

--- a/clusters/staging/worker/apps.yaml
+++ b/clusters/staging/worker/apps.yaml
@@ -10,7 +10,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/stfc/cloud-deployed-apps.git
-    targetRevision: main
+    targetRevision: staging-worker-chatops
     path: clusters/staging/worker
   syncPolicy:
     automated:
@@ -73,6 +73,11 @@ spec:
             valuesFile: ../../../clusters/staging/worker/materials-galaxy-values.yaml
             secretsFile: ../../../secrets/staging/worker/apps/materials-galaxy.yaml
 
+          - name: chatops
+            chartName: chatops
+            namespace: chatops
+            secretsFile: ../../../secrets/staging/worker/apps/chatops.yaml
+
 
   syncPolicy:
     # Don't remove everything if we remove the appset
@@ -86,7 +91,7 @@ spec:
       project: default
       source:
         repoURL: "https://github.com/stfc/cloud-deployed-apps.git"
-        targetRevision: main
+        targetRevision: staging-worker-chatops
         path: "charts/staging/{{.chartName}}"
         helm:
           valueFiles:

--- a/clusters/staging/worker/apps.yaml
+++ b/clusters/staging/worker/apps.yaml
@@ -10,7 +10,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/stfc/cloud-deployed-apps.git
-    targetRevision: staging-worker-chatops
+    targetRevision: main
     path: clusters/staging/worker
   syncPolicy:
     automated:
@@ -92,7 +92,7 @@ spec:
       project: default
       source:
         repoURL: "https://github.com/stfc/cloud-deployed-apps.git"
-        targetRevision: staging-worker-chatops
+        targetRevision: main
         path: "charts/staging/{{.chartName}}"
         helm:
           valueFiles:

--- a/clusters/staging/worker/chatops-values.yaml
+++ b/clusters/staging/worker/chatops-values.yaml
@@ -1,0 +1,22 @@
+repos:
+  stfc:
+    - cloud-deployed-apps
+    - st2-cloud-pack
+    - cloud-grafana-dashboards
+    - cloud-pe-jupyterhub
+    - cloud-ops-tools
+    - cloud-docker-images
+    - cloud-capi-values
+    - cloud-image-builders
+    - cloud-docs
+    - cloud-openstack-horizon
+    - ansible-harbor
+    - terraform-openstack
+    - cloud-rundeck-jobs
+    - openstack-guide
+    - ansible-jupyter
+    - SCD-Openstack-Utils
+    - check-version-action
+    - cloud-helm-charts
+    - openstack-query-library
+channel: C03RT2F6WHZ

--- a/secrets/dev/cloud-chatops/apps/chatops.yaml
+++ b/secrets/dev/cloud-chatops/apps/chatops.yaml
@@ -1,56 +1,11 @@
 secrets:
-    slackBotToken: ENC[AES256_GCM,data:7feZ8bCPtNZchrsdN8Rt0912vtY7kiGEEt+6Cb0I/VbiHRo0BuLACJe5YN6vUqrpWg7Fs17uuuU=,iv:o2aLioLzsLkYgfZvwinPpLnNXc+iUNdewhcg2g3MvYY=,tag:1rKbRoUZqE0acrd4XTp1cw==,type:str]
-    slackAppToken: ENC[AES256_GCM,data:dW39Q3xKBHBQdMGob/EUOXWEuILZcZQYAJhQUunm/rl/IeqNGKP+3w2IeQlITLfZxKwSdIpp1STCo7DZs2ab+dbWl4cKdRPwHaLjv45G4bPjfLoCahX0ddikbukf2aC8rQ==,iv:2l46bSfuX1In6roHqRvU0WIZkBV1yc/YXlUm1X1ghPE=,tag:Ha41Ub4oXgdv/dptWbGdDA==,type:str]
-    githubToken: ENC[AES256_GCM,data:AszzBWHz+abkZOIQXKd3hZtph6odzX3bGMhKEdHW5tzLB6sLeH/MKmrTNWDPO1JUFnDo+E3Uffok4YmPy7Ss+dUaKdtkALMeK5Y7i5oFQqVXImF+iG+oI+/Jk8p8,iv:5uCRIZ594TJZKXq1dxYgTYLdMYJk8EAY6yTcSIsyRNg=,tag:qS9UxMPJSda7Avjzzn2L4w==,type:str]
+    slackBotToken: ENC[AES256_GCM,data:XMqEehtNar/N2O2KewltnwN9/c7MJ430zNRA+vIW87DcvPzdfhZxUGnma0bH7HXz5L70tbLIgCQt,iv:8JTgoUO6XTGBlICsqN7A3SQ495oO6i0rawb4RNBd664=,tag:MjTIVMEqB3A7bctrzB+feA==,type:str]
+    slackAppToken: ENC[AES256_GCM,data:1THiHUY10UDxzLDrHKMpenDtIURQ4os8zDqamScUBblRzjYaJN6g9VmYX6J1LsSHAKpzAfzbbqC/aZM3l9hgAZ0eVl99M8k1XlMC09C9vkSGr6vxU5tB6IeOEoiMBZldog==,iv:9x2oo6VYSA/UH3L2BmL5889CskjXv33uLI2go6fw+68=,tag:oFu3pDur0tmQst95LEhMwg==,type:str]
+    githubToken: ENC[AES256_GCM,data:uV5Cc/rURVWWH84Tb19T8HuTfPIxc8obH5v2IhWZ7t140UbMmkbqrn6f2Q/3rVu2HPyDoOuMIxDZdNgdVkVAxBt63Ns/ed26+QQTsaIWVSs10N+c4nCBoMI4q3+M,iv:w4vuul7Tm7XW0H4mhDDooGJwQwrwKfHv2EE4Oe8LmTY=,tag:DH1ONgih5lcdTUGkgiwqdQ==,type:str]
     users:
-        - realName: ENC[AES256_GCM,data:KF8mnrxCtAxhr8xKb5E=,iv:HZzA0HaENNmCoea8In1jIYs6suEUPoDcAPXBs0+4pYk=,tag:4LaYsf24JJ/i0EU+aN5OMg==,type:str]
-          githubName: ENC[AES256_GCM,data:QlMTDIxSOyI=,iv:5Fl35R4xcYJLCyp939qMyJPmsi8xo7HP7Vpy1A1aE7I=,tag:v1gANaSLe2WH0BJ7vGvAuQ==,type:str]
-          slackID: ENC[AES256_GCM,data:m0CV1tvg+i1cicE=,iv:7UxT1XYvpzm218kR/cfvqWsMZJnVQ34ab17G1jTN/xs=,tag:rUr1NYjSghwlTY+ZLkT5VA==,type:str]
-        - realName: ENC[AES256_GCM,data:u1Z22bZXnVVoMMuF,iv:uxXwRgp3rIAmCC4Hm+v7zOGApAWLzsz90+FcXjAwcxs=,tag:5/fPjem+CNU1yaFddIF84Q==,type:str]
-          githubName: ENC[AES256_GCM,data:1x1HcD01KngEB9E=,iv:tWiPFVX5l9LlSYZ8A4ZokuEFMotOlSHQ3hx5KwCA2nA=,tag:cKFuFsuFysVq5/jaZgtq8Q==,type:str]
-          slackID: ENC[AES256_GCM,data:6MgGd/B7lo2uEjI=,iv:j1jI2aXb3tJX4nDRHwh5E1dphdLGhBXlD0stIfCXqKE=,tag:2XMXKJLEX46HG+6x90QXGw==,type:str]
-        - realName: ENC[AES256_GCM,data:J+IkoB0jyKZqVFE=,iv:WZXxjCI1Im0KM+S9EZm4ihHS7kYMdPWDGVhYM/oLpWQ=,tag:yTP9DCFMo7TweyQcjfFMig==,type:str]
-          githubName: ENC[AES256_GCM,data:TZ6N3mZPbZRnVsbQejwbpQ==,iv:LJflJ3kAwfjbxQ3clkS/vzVu75fdTFPXe4JdDEwuLRM=,tag:4RixVTBL5DujhehDolBjMQ==,type:str]
-          slackID: ENC[AES256_GCM,data:8wDTI3BmsEa3BK4=,iv:H68abDJCFSbEt13XOEdss7moPDUXWI9mXdbM+j/x96A=,tag:l82gexDcznHpHZAijjO6DA==,type:str]
-        - realName: ENC[AES256_GCM,data:dzhb/giY/bODV+bm461C,iv:FwrVL/g+bWj3vpGHl4n6p5YnYDmq0i8Pko56p56H1fk=,tag:niLrjMZEoqQGbTNChRQBpA==,type:str]
-          githubName: ENC[AES256_GCM,data:inpvrVOq4ttYGzPNPiUM,iv:qFC/I6lfZpYeRLypifCKm0RN8JM8Y0JvfQwL0fYFNXI=,tag:CFsMiCdIxAamVyFoAdiQ4w==,type:str]
-          slackID: ENC[AES256_GCM,data:HyRGyC4l2xVramo=,iv:Xx/9yEJbEp+UxXpbcX+ONRUmKVwpeQejISNQEYior/4=,tag:hLY44ZKjUJWIFNjQfiTkag==,type:str]
-        - realName: ENC[AES256_GCM,data:sHPzy6rUvl6oCFMB9Q==,iv:GY/RizWHWgHr+tS85rIKviQCtuICGDw/XbZjY6q5JyM=,tag:zAzh8m10YIQS1U/fC0KtHw==,type:str]
-          githubName: ENC[AES256_GCM,data:AllY3xTsHZw=,iv:785/25cJQeARGL0/V/z8vRkBuhBYUDPpSd2T+d7q5u4=,tag:Mird02Loeoi73B8ifXr0jQ==,type:str]
-          slackID: ENC[AES256_GCM,data:9uQfu2XYkIBTxLY=,iv:Poqelu5KodqG0Wf86FufTkZ8JcH+yuBXsM1bOSd3TnE=,tag:Fb/vyIp46u37U3BZSZgQOQ==,type:str]
-        - realName: ENC[AES256_GCM,data:rHjwqEVNnBf+dQ==,iv:z04ctSOkt0QphaZ2ND7JHb9ol1l6q24rTf38oc9u+ug=,tag:UQWRnT454HGKjCSkmxOvFg==,type:str]
-          githubName: ENC[AES256_GCM,data:8kaamNjeqQ==,iv:wdbIwVrOV//fM8y5zDgtkcfK++VIgdLErhET0C0t0dY=,tag:rrxCFqj635I/TjXpgSuvpA==,type:str]
-          slackID: ENC[AES256_GCM,data:RcRcM0bQEIVb,iv:UMGwqTk4cs+nBQq7cwvx5/ZaB7WktVMpCQ6VfgT0TT0=,tag:ikAmQro1Od4xt91UWntlzg==,type:str]
-        - realName: ENC[AES256_GCM,data:/vyIqC9Q7yCGvxhv,iv:EPb5r7zmXy3ggmUoKhUVbPV0fyxNWoZtGwJCpRkdq8Y=,tag:hdBnXVAU0tsbWxLmP1MA8w==,type:str]
-          githubName: ENC[AES256_GCM,data:QXsc8AaHRw==,iv:XWgldbFbjFCRRJQGu1qKJf01Ak3MGIKpCL4H113ByYk=,tag:xpPCXNyQM2CuEYNala0rIQ==,type:str]
-          slackID: ENC[AES256_GCM,data:9TonB5XuKS0/Fw0=,iv:QejLO68mVcIOozuPg7Nwmf20WXE+fxZv2m++BiR4VwI=,tag:UuKAIvLzJgp/qoBc00mbgQ==,type:str]
-        - realName: ENC[AES256_GCM,data:KLzS4MJqEGQnpypqxC+Y5Z8=,iv:GspOnv4ddtHU7WtoRhvffSwORhUca/N6+pqu/HUQI94=,tag:WH2Qwcrdz5C/LiXNpHKqsg==,type:str]
-          githubName: ENC[AES256_GCM,data:ymJ3IU/f9kp2,iv:78UVKefvrjQ/TFb5n9cy5uc5nmDneb4VLAhaLqrJJMc=,tag:6HvrDfYP59wby8GLb534FQ==,type:str]
-          slackID: ENC[AES256_GCM,data:DEpcnfnZ0ITtsRs=,iv:BEwR2aqDzvCO1B0L8b0OZc/1/04v8Hg23Y80CNuUsCM=,tag:6JfDrnJlEnr/LSRsv/PqLA==,type:str]
-        - realName: ENC[AES256_GCM,data:XKJpYSUCs3F9hQ==,iv:3bmdkL1Uf85xZZ1uW2+QRAeb7iuELcg8EvJLWJsoIiA=,tag:80wtbpRob8bnJe4nc/Ha8A==,type:str]
-          githubName: ENC[AES256_GCM,data:hsJAXOpHgjhGPg==,iv:GLGfUMiANv+Rvew4FnWVWWsfLJSXIs6ZRyjPRnAtji8=,tag:j/oCposZiTorFPlnsgHR0Q==,type:str]
-          slackID: ENC[AES256_GCM,data:TXer7tUleqCj,iv:aMn8JHJkCEqn3JfA7zc2dsQIqBW+Wl26R9R5RLrFM28=,tag:JYV2ohcmfVFperFjUQisTQ==,type:str]
-        - realName: ENC[AES256_GCM,data:kOFmu8rpw8kUpCzz,iv:jvKZGByY+iRyADYmckWyV/t6AikFN+k8yWKU0bTYwbI=,tag:pBpXZW79eqn+Uwj1Z7r66A==,type:str]
-          githubName: ENC[AES256_GCM,data:ACLI5EjZ1o32/Q==,iv:i7cobhuIYCrvJ2cEMlynJFl4odrvEZwEJvczb/aApTA=,tag:nV0c2bAjnG9FfeBdPCKaRA==,type:str]
-          slackID: ENC[AES256_GCM,data:XC3PtUMesRQEFww=,iv:Md2Ybr/0T8veL3DH+NguJIAAYeEXKatN1xUPHL+swBU=,tag:LqAghWUlBJZmB0lhyO00jQ==,type:str]
-        - realName: ENC[AES256_GCM,data:v8blZwAeYVatISM=,iv:5jVJ5ZGVCE17bduvGlRaMuh/m+0IrsfUj2n19tKZYO4=,tag:9WNyTawWknkVi0ty5gifqQ==,type:str]
-          githubName: ENC[AES256_GCM,data:Vo9dIPOVmanfLGQ9,iv:6DTnplsjGjq/w6uwjZBThS2AXoIsJZbBxULhbNR9TcA=,tag:sY9x50WJTpA+HcQfvn4LRA==,type:str]
-          slackID: ENC[AES256_GCM,data:JRoWSc7gGnjA2bA=,iv:7LlbNb6lWGQYy6P1INtJy9SBqcbb23+vaaApUeprsT4=,tag:fajZG+U19ngmw/4MFSdo/g==,type:str]
-        - realName: ENC[AES256_GCM,data:SVzTlgDQ7R2LPrO2cE9N1kg=,iv:2XomqM1DDrJpXDEzpephhb06BDd/oeVgtnbKVO+n+ss=,tag:RPkT5AefQTZvX54VzEn41g==,type:str]
-          githubName: ENC[AES256_GCM,data:7vhE0ZSDCdzCBoUisOIjnhc=,iv:+liLUkTOX5M4D3ar1RmcngEk4zlHklXtZsZ4P8+gSvY=,tag:tT0qbXHJLExe/+pLfMpFYQ==,type:str]
-          slackID: ENC[AES256_GCM,data:co2kL086h+vY5qA=,iv:D+H7lQGFuOsKbUb8VmvdS4bUpi20ZHwXW5aiRLFqxG0=,tag:3GNdInIzYPEsxD5DXyHc1A==,type:str]
-        - realName: ENC[AES256_GCM,data:SUP/cG6XnxqkDAc=,iv:dx1+gOdpaW8Ag9+pvvD0XaqLLTKd1ywqYdQmUuP5Qfo=,tag:BJoohs0h5hni9FqwX6QpwQ==,type:str]
-          githubName: ENC[AES256_GCM,data:dgsfXaUGYtZ7gg==,iv:AFln72ktG1UhRWO/LkFLAlB0dZH9hASdAUT86pqN/m0=,tag:BRXhwzZ2YSMNAA9mzRZPaQ==,type:str]
-          slackID: ENC[AES256_GCM,data:Fwz6AdOf87jEk9o=,iv:vGBk1eKkDPUpsTODY/O1E/tormdL7NynfXrD96V5QcU=,tag:gTghhpdD2dfadOLjCpjmPA==,type:str]
-        - realName: ENC[AES256_GCM,data:VoHzZe7hb/myaLN9/A==,iv:AsmjFlnZmRoPH/bGLI893apPIkRTDZnqp/DNzLDggrw=,tag:ZZT7pUaGZ2KlAeWbzFhLSg==,type:str]
-          githubName: ENC[AES256_GCM,data:1MxZoyQjofBh,iv:1L5OTJc7WQf2Oy1g+d3r/jRC6ta5l/6d5vCyfsA4q5o=,tag:wPOLOsikkA17a838ivW5vw==,type:str]
-          slackID: ENC[AES256_GCM,data:LhamdUPkpdTei1M=,iv:K8X7pZWIIPK9P5aIDEFkcu1r4zMHTlSV2aX0VU3+Icc=,tag:ctdnRN76m8DoH1e2LNqfEw==,type:str]
-        - realName: ENC[AES256_GCM,data:Kc52ZLZfi0dbKvw=,iv:YyfYW2MeH4IAA3LUcJZX3NmfcK4ZPkFP7tEpJMwq/pA=,tag:NzzJxVnZShS4ijJlq/+mCw==,type:str]
-          githubName: ENC[AES256_GCM,data:nrLLGlTHaZYTKw39pIKYJnw=,iv:3DuyjnDw3hv3uR1mA8ApfXkYNpmdcUwFMz0wBTYApkE=,tag:TJrxTBVzovY+cmmCtU+P2A==,type:str]
-          slackID: ENC[AES256_GCM,data:MStG+R0FY2oN6P8=,iv:WH6IvRkvDKA9OcYaHYn+jJsbZ5iFPyk9IgbD8U3Z+bU=,tag:fD55TFw7L6+M8KAT0z1rug==,type:str]
-        - realName: ENC[AES256_GCM,data:kc6Lnl3vV6l4ypE++IK3,iv:YjFS/JE3nRj//gY5om4U2ckPObpj3rfIzWRSM2zIyPs=,tag:GNNrnFb4U0dhxinwafL8JQ==,type:str]
-          githubName: ENC[AES256_GCM,data:zIQKv8hVppIGBBw=,iv:xfh7difAqxCzykIiWoxk5uoZu91KimlyuEXjEbvN4ns=,tag:jqURHkLT+C9t9dqXdVxKFw==,type:str]
-          slackID: ENC[AES256_GCM,data:+tIrE5WPJdcMHNM=,iv:SAnpHK6SSxxjyC4frHPgvojwSLaQp059uwV8RO+Ww0Y=,tag:jISUjBWe3fXsHIo2JXvCeA==,type:str]
+        - realName: ENC[AES256_GCM,data:2BtgHfBewVd7BXdxwJM=,iv:+NjhpJQXWMjJSWD+zRhASxrsNQ58TxibhIPhWJpfRfk=,tag:oLmvkLziRo7H/KhmEAe4ig==,type:str]
+          githubName: ENC[AES256_GCM,data:wBCOd/mOYYo=,iv:K+UT5QcvAxJMKhJpNhuo8urxB1ZPi7XVu7ujmfIswe8=,tag:Iv8RX7hf8d5V6bjGwOTYaw==,type:str]
+          slackID: ENC[AES256_GCM,data:SuJIn3AtZigR+Bw=,iv:c3svf8wowW+q28Q46DQSHP+H6SOdNAND8dnl+YwWk2c=,tag:wHU2UZbbcoGUGuGBvenJYw==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -60,77 +15,77 @@ sops:
         - recipient: age1leemhq3me8d4vtnuful0mlqdtjd46k2mxc66nmck7zwh9c7rw92srfdf3c
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBONzZBTFkxL3lSZHZRTUpm
-            L21yQVNUeXc4VW5ZMWtVU1E2dFhjUk8yWmtBCm1uczVLSEhzRUVpWWZGYTdxZGda
-            UUFWaXNzcnJrY1g3aHdId0VjR05ZSkUKLS0tIFFLdjF0TGc3VzFEVThiamRwK2dw
-            RGhsWjdDWWkyTlNGNGdXYkJZTzB6dTgKrc5pT2qJXXRQ82iGfBm9+yKfnSB0Vqav
-            7M+ph4vpGfJWTA4mcAjAx4IcONzJ++Y0sIzjLKACyfSNMi5QIok4bw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIZTJlZ2d2dG4wTlVuMWhn
+            UzAwT3F4Zkl5OEdBWHlUWlBMRmFzUFo3VVRJCm0wNWdDOFVFR3M3TEFsV0FKUkcr
+            REJjU2FKYzFxRUlldHUrbStWY3hJREkKLS0tIENjMVU0SVpWb0RnSEdISm5OeStU
+            NGQ3SXdRazBOOFJqTlRYRU9PRUppaXcKQcgegZeuokHfdF22S/+4izUe5XOQpk2G
+            VtsVA4RfIflRiU/wNh1RVXQExkFg1TSBZ2+FrxycNh/j+TyEQ34djQ==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1acqcungzwkt807d3jt94ngtdt0vhk9kec4ps4a22cpaah57jw4xsl7q4xc
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTelFPQ0dhbkRvMkt4eFNW
-            b09YUm1JZU92SDNGejJaNGFkVzhZYXFWQ1YwCkpLVGwvUDQxYkZhREVUWjl1N1Jn
-            S1IwdlY4a01zMmFFTG5VaVZpVktTVkEKLS0tIHk4RjZqcDFRMnVpeTZSbFY1SXRj
-            QkdycjVYaGdyQW5ETDNQaENQa2FBZDQKZ9KVXuoJs7bG9c9i+4b4P04VOGG8uOtI
-            TlBjcq42uRkeZ9qEjye8log7c+UXDcKI+NFlF1M/vLarBnDpOiiDCw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUeXoxZ2xsUll2bWYydlIy
+            cVJpQ0Mrd1BrZzFMVkt5bzlFOHh6UlFmbnlBCk9nQWJqdlZ6UytHSHpManZMNHJN
+            Y3c0eGxXRHJoRFdORE0zL0RjckYwcVEKLS0tIHRkZEJ0VGxqWmlZaW8zQzRlMUUw
+            MVlJZVFCMzN2ZXMyR0syRVpHeWlWQjAKkDHUYZ4Gbm0ty+PQ+boTq1JYLPiYdDZ3
+            RH31chQUJenWV/qU6fEk39s+wJAyf9nXwm91rATGg94JPFmQblLHiQ==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1h3dmygqf4v6jg3nxk5sr9jkp27w3q83sqnqxdd5n92xf3w6fs5kshakrxn
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEdEpiVVAyZnZETlBGVTB0
-            VzZlbW5PN2s0dnJmOC9qaFFIdkdjYjZyTWhnCnRSaUNVcU90bjdlQUlvOXVlN01s
-            UUpBSDhzdVFwaDBrbzNJMEtraXNiUTQKLS0tIEZmaTY1OHk4bGZWVlIxVkxkaHFx
-            a1lFWktCRjlDRjZtdXIrY09nd2U5ck0KkCL0e121SR62ThIDeDgE5tZoWCXdiDBO
-            bafONc87RxkoWMwryIbeMWpctImrqzBEvmWxQb6nmkADrbLcchnqqQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByMW43NHBWRVJLNUc4OXNC
+            V2lyNXRVZHFHNmh2TmllRTlKU29zUXlFWEY0CkpaWFMvM2RIbTc3cWcvb2thbk42
+            bWo0VWlnTkYwYks3K1FKTTN1SnE1Zm8KLS0tIEdFaEQyaUYxSWNzZU5zV1lDSTJt
+            MHNGUElWd1B0T01mSlhnQ1dHY0VSYTQKgLepKMT7i10jXyU9rdjHoCsIKJ+PhGo8
+            y139X9kXDuiI+ChogBt6m5ggJh84aU7HJJArwWT4CWsKbLNGPbLiFA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age12khufkd7z25eqgpjjyy0zcrq6kpjxzekmff5zhq7q54tajm4e58qul35x0
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWNUVNdFFaR0lSWDY5YWEy
-            cVJheFQ0dW9PYWQ0MWZVZ2JHN21nM3BXMmp3Ck1oV3JJbE5DUGhwdTkwTFRORk1h
-            dmpmeWVTTldySHlZQ2ErWWpGb1Y0NWsKLS0tIEJLcFAxQUFUdmZjTGpOcFJmTEYv
-            TlNlanN2T2ZjWFNkZE1PcTNCRzVHVm8Kprcp1+V8zwe9zIpjlwbsWu0fELVf5sZ6
-            uA/7c6n+LrV8IqURos8pqkRbRO4GyfCjDIY4r5IpYK82lTblaRLRdA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGRzZFdG03RGpnWXRzcGlB
+            V0FuSkhQbUhNek40TkVGazdrdHR3UXR0aXdFCmwrMmtReG9mM0xtblFuZWtMQ0VB
+            aFBGTnBBTTBkRVQrUHlZOVU4SUpLMEUKLS0tIEtvTDBMTGZacXlZWUEvSW8zamho
+            cCs5c01pSnNKTGpzUUFRaHRNNkVHZm8KNh59vT882OZyXiUxiwmzRCwCo1IkfPGA
+            fw2HxBb0KZier5POzIUUEa0u9BpLoC7X+p1I3ecoFS0LygVSLakfsA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age16fufeddr0arrns268526gxethxgkh3g0euf8cn37kuwfmq3h23psutz4q8
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3bmRhOUpBZ01VMm5vcU4v
-            anVRdkdSd0UzaCtGemgza3BSR3piUkJxYlRBCkgrbnUrd2Q4OTBOakNMd3dKZlJp
-            VVRlZG5VNEJEUUJROE13RWRQRnZGdE0KLS0tIDN6bDVzdmZvcFFsdll5VllYZ01O
-            UGZweHFLZlRaa25uUkorUG4yZDIybzAKaG/sAA3fOaFEtYiF9ZAwLFIVve0IDiJm
-            ArjLsVyAV26ofYbndY5fwaWmJMYt360ggNT6AEt0fMNSlNzVMkksdQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSVnlaOXFkMnBRRTk2cUg2
+            d3l3SWd4WDBDL1IrckNwRFhPWTZZeU9MS0hRCmNObHBsK0FpQWMzY3UydUlTZUZs
+            MkNMTnJxS3J4dGZvZ0Y2NXQySjRQdGsKLS0tIExpZzVYMDVpSlVzUDI4dXBjQVhL
+            L0FOdzBad21ubi9FQ291QlNzT2xWZzAKerJKHyLlpVOnvbvLE5Jpg8XMki2fIL7Q
+            JKbo9t/D/9as7O9PUB64NniWdkfU57Bza1TuxBOwROpCL9f5/ia0cw==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1a8e4gxw67kp27s3hssfxyem3e8jwaha3huz0sttfngeu60pk5pxqkfpg3d
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6L3hMK0wxZ2FaWGlLYW8v
-            a2JzeG5BUnN3MkV4MHZEQkw0aW1QTmRpbHd3Ci9TcUZ3VllHaVJPYSt6Wnhkc013
-            WmZPQjZLOHlUQWh6WHdLZjNreExJODQKLS0tIFc4OS9sdzBDSkIzWmh4NGpxRTE3
-            dU9uR2FGOXowRUM5WGhuVmtlZWYrc2MKEBkPSmvrR7EG9vW6ejLpncCK64hkHgEe
-            gqT9n9u2f2fihmhcFh6I8BMCRs4R++O2Y/8h5r/fjJ80/w97zTQDHw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnMVhhWnJ2ZHUwdDdvNHNH
+            Rm14UUN2V1pvZ1Y4WGpYNStXT1dKdVkxNG1JClhNRVRGYUtYNHhxRUxLT3lHQzlz
+            dG0wZFAxUnlvWFRWSzRmK2pFRHhtZUEKLS0tIGVHN20rckFaaHJwak1xUk5JTzI5
+            V2JkTUF1MHh4K0hoNlc1ejl4WHVtWlUK5G6hFXoqGOHPz/wESZ7HFnG/50KVtq+D
+            ftvMUaWKArU579ut3KNNjjo4n1r8RrnTPyPoBncgxajX5mMjWloPxw==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1drky6caal0j2x58yzpw9tyflcpdpmcjqy8nss7zfvspszg0xfpdsyzu8s4
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLYWRCNno2RkhGV2pxd3o2
-            ZUgwWm85bEpPM1JQT0hmc0JyRE41VitDRVZvCm1RWnphL2QyK2I5RU5EWmtIcDIw
-            RWNSYWIwNlN2SGw0K3EvVnB1NTR0NUkKLS0tIFdMdG81M2hVS2xrVUtyeUV1WFBG
-            bzhWUGNmb1BQR0oxY0xmVkFUc2Iza0kKmVD5ncO5sNChHp40PQucBmZnTcdh/Dn6
-            B5Z5EfNOSjXF5nEdM5rmqtPAoBxu+yH/HE9/JjHAFNInRUQCG4TUdQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjaUl4alJVemRzQlVGVVNZ
+            Zlgzc1FPT2JkUFppR3hzYkh1QmJKQ0Y3Z1M0Ck9JdmI0c2N6Zk85Y3laZmtQYTRk
+            RlN5QnpPNmhnR3hNUFE1S0JRY0tING8KLS0tIFUwZXAxNXgvZEFKbFliMnk3K0d1
+            TnhoWmI3OUVtajFVeEF4ZGM3V1BPVVkKFhel6W704XqiALVhVNFmUNhwBMVxFTf3
+            IX36cXPF2Rbim3Gtl4T8hXDHfULfplKH1G9u/BKcDwINaeEUVBsorg==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1m57vjw60dpr02ghka8kh2xlqsa0ggxauau2y488zdh89vu760qgqh8lcge
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5eFNPWTVZc2RTdC9jRnk5
-            Y1BiNlZDMWU1ZU1BMjBtRDJtZmoxZC96NEJjCjhHQ0xkdkpHTEY5eUMySTlrNHh0
-            aGw1Yktvb0kxR0pVNVdrNkZkbXkwY2cKLS0tIHhVM2dHQmRxRytxQ09WcDQ5M2Vr
-            L0Y4U1VPaGtPV1h4ZXRYV0NCeDVPQkEKQlcATrIcc+qS788yxewqTWDVd73eKwPp
-            Htp4g6Jop4nemoLkthS8Cj/0OJUvihQ9WHMVNrt7D4uUctiSVGFC4A==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiM1ZpeGMwZ25NYjFNSkhS
+            c1BMYXdySENBK3d6UXBmYm5VUXF5QlA1NUhjCjlXUk85aG5qZUExeFdxUlgwZlJQ
+            VGUyQlpWbjBzLzJ2ZXZQL05ZSFFmZjgKLS0tIG45cFdWa1F1NUlPbk5SdkFoeXBa
+            SjFocFcvSXlwdTMwd2p1eG5SVXRESGsKDEb73b07uiNsSJgpDVN4S5TZCWcPw004
+            Uemi38m1gckchRr4yEPEd6NjqGVr4aN9lia8Lf0trTNoHC3g/A+QWw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-01-07T11:01:28Z"
-    mac: ENC[AES256_GCM,data:e3/50cPpGgsbDaBeB9ZJROj+tj/ZG7W0myNevkwjcpfCQhndD4vFORu47UwT/ng515XCVojcbyOU6eBu7dwKSCNgEcFAsPGEiZ3L9CUesm8jd3Rl6pd856gPOAeubxuwjp6uEQ0eB/tCrsKfumWjt8YAJO7aLbquhF+jsO6nVRQ=,iv:wsQEDyr8wsQWKjwCIqby75PUgZYNJtipw26DCt+2FOg=,tag:d/tcVr319dY1vIdIJ7DlSA==,type:str]
+    lastmodified: "2025-01-08T10:20:45Z"
+    mac: ENC[AES256_GCM,data:TOWDRSNOUnvfX38AIYEEBoXp0RX6Pz1Cp9/NOzYN3ARMDuhFVRIqAzqYDPIDj6uHjb889Kl0tHt3GjciaU9xED+2KYRpKAlCXo1PhGXsIU9aYnCepplAmN9TJ316ElipkW41w+wizNe+zI9q5lbQMn+LYij62c6gCRAo3pOAKUU=,iv:ToexNSrIpwk2nMlxmBoqbhhdMzFDqmKb5soy2+N1Y+k=,tag:k43AfPe88tF/wh/6/Mew7A==,type:str]
     pgp: []
     unencrypted_regex: ^(apiVersion|metadata|kind|type)$
     version: 3.9.1

--- a/secrets/staging/worker/apps/chatops.yaml
+++ b/secrets/staging/worker/apps/chatops.yaml
@@ -1,0 +1,82 @@
+secrets:
+    slackBotToken: ENC[AES256_GCM,data:g7ireT+v77xrtIbtVCnHdhj9oCXO6bJN8uW0AfUAdT1+/AykQbuo2y9I+KoprovHhf1WwzzNVyY=,iv:T2Iyq3GP93v7Yaxioxs5xuG8dq5W8grrBCQdIWGgC68=,tag:/9YYKv4hv/AF3mMf7QU3iA==,type:str]
+    slackAppToken: ENC[AES256_GCM,data:Y7sotDLiVFSohlD4Xtx5CUSKQgaCCZE17CJ0FQYNG/blFy1lZDjx7vSP96iN4E2mkJCvilsBydgARZtd4zdkdsL2qQOI15zvBW9izfN4Iy0y2xO9GL9/HThhnCRsRet/DA==,iv:yaVugV4lo9h6+ElREhEeAhKJXpimSy102o6rU6nV4y0=,tag:nrwB5XE6iBumnLmft+lJkQ==,type:str]
+    githubToken: ENC[AES256_GCM,data:yMSqBGheSszm7pgAANV+G7GNhTU1seZyDoJjUyQKfJN4ayq7UyKw54JLpNJXpj7VC2fs4qsx/NLwzSwkck/BExE334yfAX1AnlOVRgiqYjkz8vFHvSyc+aGC9PTw,iv:91Cs8sYxsZConynTna76iKvD6QZRP3hjiQIJkCBlIs4=,tag:xdIIpfp5/A01is7CGVgoGA==,type:str]
+    users:
+        - realName: ENC[AES256_GCM,data:W2OWMkVm13zEEJN0SIE=,iv:fmp3Bdg6VrxNL+sDj/XDNe2WDyu828Ht2Dc2guvDtVE=,tag:XoTFKIexZKqP5kNyaxiDbA==,type:str]
+          githubName: ENC[AES256_GCM,data:91SCIBFo8ms=,iv:o4zNTje/cTkRKL0MWBf9nTtg/HhPU8T/rDzLj2xihXE=,tag:OBDbDTcEbWeg10Q2Vq5Pkg==,type:str]
+          slackID: ENC[AES256_GCM,data:DBsUrPItvy189gI=,iv:uauWXQM7zoA5Dy2sIq8zAwA26oKNg+7WTq9qWH3ZSLg=,tag:vRMX0x4X9VyTAGrk74YBVQ==,type:str]
+        - realName: ENC[AES256_GCM,data:H+ZuphBA+ENaK9//,iv:lGwwl+d3jyYSoXV/fC7U4/t14YbUkdYLVLVcxbwuLuA=,tag:k9WZ5qmQvWxldbhxb6IDcQ==,type:str]
+          githubName: ENC[AES256_GCM,data:1ReB1MRx1jFbtN8=,iv:+SQpDMSVaerBREiqgNRMmAj0bFjTWNh1RXHr/uPQLfE=,tag:RgYVYBPDaQn0oMoGYf911g==,type:str]
+          slackID: ENC[AES256_GCM,data:806Wn/Dst6cQ3QY=,iv:GmGDla/A2B3EV/sgDdTBpb7Hcph4KtOtWNkyw4Wtx6A=,tag:799FtZv/I4IIoFjID7DqmQ==,type:str]
+        - realName: ENC[AES256_GCM,data:ldOv1bjrU0nQYNE=,iv:Rf7AkzJWFNGduEVTc46MYPzrcSS2ISO10Jhv6rAWoho=,tag:LycA1uR0eS8Djg5nBFRj7Q==,type:str]
+          githubName: ENC[AES256_GCM,data:df3hs1IZL4oZcZa6nZeTOQ==,iv:qEC9JPqVnltOrkD126rsJsQBepF47uEVl+ERyKKpfSc=,tag:bIlG1+HHMnqT6TyQZQMCAg==,type:str]
+          slackID: ENC[AES256_GCM,data:OFJcIAvab8Ditlg=,iv:HKnZgSBEDgr0p7eAzqOz9Hc+GoNIbErcR5QXkJoeyXM=,tag:9lbpzGMb+9t1zf7vdCcTqA==,type:str]
+        - realName: ENC[AES256_GCM,data:T9gigKu/a5CJW7Li850Q,iv:/xb19tSDrHHx6LkRNi88ihD+PQEY0ZjVifYnMGi+bC4=,tag:b4MQfmkpSeOfepjbOXAVdA==,type:str]
+          githubName: ENC[AES256_GCM,data:StdHXCKlyxYvc1iRAj5P,iv:WdRLuBGs6XEKhBoyG2x0i24RpW0Mg78MwyPwVaN5o3s=,tag:/ObQXOE5SGNSBfPWxxehfA==,type:str]
+          slackID: ENC[AES256_GCM,data:natc1D7j6o3nl+0=,iv:p4PxTkjas9PFqgBdMlGjs4zKCnGGgCjboOPJ3xriteY=,tag:bbFuBR1zI3vWjvBMF2CnWg==,type:str]
+        - realName: ENC[AES256_GCM,data:GDAUSpuSxdAZwM3GZA==,iv:Qi9hPhLkEuU8i4ZKL8lSGW+NnvmGZrhV+qemaXn+zHg=,tag:B18W9SMH3YX8mwqcrm/4wA==,type:str]
+          githubName: ENC[AES256_GCM,data:pWE+KdIPJkI=,iv:Pn9+x1WqehwDNGPWFj+L0GmqZA5y/yz8oyb7BaAsc7A=,tag:wiDeBOYEMu4sptTSidNv0Q==,type:str]
+          slackID: ENC[AES256_GCM,data:zbUL1qonJmXhNwk=,iv:xZGRna9J3+LL6Bd4a7cwZdDCkX2+3deID/gK5rnDGm4=,tag:85bw8cmtMTE9nB+f3HzcAA==,type:str]
+        - realName: ENC[AES256_GCM,data:N9ZsCiI6PiNYwg==,iv:XOxT8K0AMssPOCgbYoQ68Gme4N8nTr0wnaxYG264j0Q=,tag:IeHqXjGb06fSgSkXZVj6hw==,type:str]
+          githubName: ENC[AES256_GCM,data:hwF4YUeE7A==,iv:9frsEqeohCXVX7TKQoBCYJIBQC3K41whQbNhqyTFqBA=,tag:inYPFJl50p3tXafWnt9OzA==,type:str]
+          slackID: ENC[AES256_GCM,data:BXN3C3WgaX64,iv:0IPUB697JumCvK+nfoJwxRPfjD4+ztYr/rQsE9gEzdU=,tag:Kk9OHjCoGiHdLHxy5ra8OA==,type:str]
+        - realName: ENC[AES256_GCM,data:UndESIE6otphDN/t,iv:aoQJ5Wr+Wwli2dkliQ4wsKotNfMb18Vx/Lu3PM/oDZk=,tag:L2gimgn/0eKzvCdD6K3vdA==,type:str]
+          githubName: ENC[AES256_GCM,data:FlqUQoocnA==,iv:LbW5sCfhSFvTZ44PYwzrVXg3BrHUzduabag2lkCd6uE=,tag:mNBD2pUdL07HaBOKDOU91w==,type:str]
+          slackID: ENC[AES256_GCM,data:mXRYDX0WA3Ezy+g=,iv:vECya4s6p+3CXb1enjj4f9Ka+fjDpcvwnQl8t3h+Gao=,tag:svNJPOgLgvegp0TjhCYe0A==,type:str]
+        - realName: ENC[AES256_GCM,data:9EOfjPEOzNQDi+0omcacHb0=,iv:mgZ2YqhP9+Eb5Oc/F+yninhfPl/9mOIVllzfDRLhyWo=,tag:bRpG/AOl6v5Et7ni7lnp6A==,type:str]
+          githubName: ENC[AES256_GCM,data:+Qs7GI6BkEJX,iv:RgwleLCHYOmiNPpxk5EjFRHVfv4fhtBoE6erXgt55Co=,tag:7Kn7P/GT0plsSePfRr+H0Q==,type:str]
+          slackID: ENC[AES256_GCM,data:bFr+LwzVY8uI8uA=,iv:ZRFULYbnDV8wUFsqvwVdJ75BDhimBaJAra0k3Nt391Q=,tag:z31KfgIZ2eRlfLElCZ/ZEA==,type:str]
+        - realName: ENC[AES256_GCM,data:LIQaKPninYujwg==,iv:gi7loYpJl7Bnqnem/fy08DWnXUV4AL6R4MSdrQlrIv0=,tag:zIC+CAupibeILrrD/pE/kQ==,type:str]
+          githubName: ENC[AES256_GCM,data:WCQW8Vd+w1BDFg==,iv:UiIbpzOy0KIP0iQQoGZz72D9vmTRTDgY6a9Hr0snUuk=,tag:IHPM/UxEiGkzbL1BZoPNdQ==,type:str]
+          slackID: ENC[AES256_GCM,data:rVmiffTDjddS,iv:ve35pdp+AHzstKLESsjocW1a4OE9aU610PhiCAx3Be4=,tag:vcHJS+iYnCfC91Ms7npeNA==,type:str]
+        - realName: ENC[AES256_GCM,data:rhG/V7Si8CUUEJaW,iv:9omh39nGZjRxnfSvHYVR7WDFiwFQ8dBD1dPC9Xkzd6Y=,tag:MQsxYbeOsLO3+1vs7+qI/Q==,type:str]
+          githubName: ENC[AES256_GCM,data:Wi1s5fHcJB/E5A==,iv:T+/aL0l2ghuc5ihxK/SyX5uJR8VE+hqOfh9c/AlHwqg=,tag:ZD1671OBx9aan0iFTltnQg==,type:str]
+          slackID: ENC[AES256_GCM,data:jYlM258mTNt5/dI=,iv:mm61lI3INuF5MoWz+pbGWJUEYrtKAApSS6k5S+m6aqg=,tag:WhzLBFLGNa6jitVv9E40qw==,type:str]
+        - realName: ENC[AES256_GCM,data:DwiLO/GQg3r4Ufw=,iv:c9ZIIMtqQHwS0eekne4+G1U6bAxpA5j57M0WraKHYvU=,tag:1W0/qKbLuZ10TV0V+NpM4A==,type:str]
+          githubName: ENC[AES256_GCM,data:QPdEbbPA1C6xbC/T,iv:O3d+uBFUFBS5deMEC+tefcmwJE9fYm6H1uWAuV/W48Y=,tag:1wZC5DYrQYbwnkmrc2ENLw==,type:str]
+          slackID: ENC[AES256_GCM,data:e2j7/FnVRRxU+IE=,iv:iTvU++T2IFFZDPqVuG4HI/ADP8SNAfMFLhP2w28Qg8Y=,tag:eiBx+1KmS5sjNFUJJfYqnw==,type:str]
+        - realName: ENC[AES256_GCM,data:GX3XUBOmTK5h2MzftdsAI1g=,iv:FKMDYhqFoelqovOQOkz9ygA1+gcWzAf6XP3h8eC7EvE=,tag:bR2nVnQt4dTkaadYrlM4Iw==,type:str]
+          githubName: ENC[AES256_GCM,data:Y4iHbP7YzlNrLGWPUFDP2ag=,iv:SGch0fr1hbaHGziSzM/wokmToNKNmgybWt2lb/pVaQ0=,tag:KQEspwITr3xnCJr/+RnZzw==,type:str]
+          slackID: ENC[AES256_GCM,data:uF+NpdTywuzXnGg=,iv:def86aOQT0e9oDbIhpMCth7iXgEqpxvBnr0DqTrS9w4=,tag:K9aWcyzGQsT3cTC8bU913w==,type:str]
+        - realName: ENC[AES256_GCM,data:JwdOeiWcdQqQPbc=,iv:ToHtCQ87MQMTfkJ7GUxg3ESuJy8Gnsz+5rgOhGMu3oQ=,tag:egXIU+YGiFDzvF+Ip8tV4Q==,type:str]
+          githubName: ENC[AES256_GCM,data:ZW91l7KcVu0qww==,iv:3wkqLlCK2kmEHij5GK9Gorws2cnnPtfZspaFj4UZBZs=,tag:21iPVyEmkMfyWqmLyCw6QA==,type:str]
+          slackID: ENC[AES256_GCM,data:G6s1u6zwZrZQF6o=,iv:jAMatzsgcr8L+9WPm2j0ePdaX+AyJjEL91T2KLKLZKE=,tag:rAHfotKnZ4cANQBQa+cR/Q==,type:str]
+        - realName: ENC[AES256_GCM,data:tZIQvWnSP3fxVPZkCQ==,iv:vG+iAFrHCtpqp1Gr9WTVXI7FuQml6urYiKDRItsBs1o=,tag:rKhM5hKdOQNhMBiS5/8+9A==,type:str]
+          githubName: ENC[AES256_GCM,data:WebKwPajkqJY,iv:dgf0adpgvcc+zp8NbNRJeUd+b7uNGYEFjTOb6YapbwU=,tag:F5qCCT37LRM7eWQD/zjXTQ==,type:str]
+          slackID: ENC[AES256_GCM,data:f1oVQukIkHHo3l4=,iv:P0Ztjv4/rJi4Klfe6QPd2GVRB9vZiApnGsQCg9vG6NI=,tag:9Y+zhkBa+HzeFxI3nR+gCA==,type:str]
+        - realName: ENC[AES256_GCM,data:yjzUBJ8D5bzFGEU=,iv:1ee7KTnyBjSIq8BDKxXe0KAe/DtI6QQCdC1KjnTxiqk=,tag:njdGXJYtsaxND6AQRBuKcA==,type:str]
+          githubName: ENC[AES256_GCM,data:oohN9wU/JUP3Ku0yPWnfQAg=,iv:vHjydIqxf+CXGnTXXVKfN34hdKEqDzeeO5+GqW3ABR8=,tag:pzWtlTxE9AXgFdWLeAtTxA==,type:str]
+          slackID: ENC[AES256_GCM,data:kkzHjeerWVcYQzQ=,iv:/eDZtUxyJ8Ux8L+JN1pDjYnxJtT6SqqHwFCklaQouOc=,tag:MNULF7LUXTOH+0AplAT8lg==,type:str]
+        - realName: ENC[AES256_GCM,data:fpCpgedSDGtg2LknZ0Lo,iv:iJVOOHZ2NJYmrrn6x1/QJvyPp1d6IuIVDmc1w2mE/eA=,tag:I15aQAakxOCiS8QLUlzzBQ==,type:str]
+          githubName: ENC[AES256_GCM,data:fn7Z8z20Ro/5LEk=,iv:U5m2C7UAZJ4ajImoOvThk+VZ1arbpvtV6snNtRZq+l8=,tag:mfKnVC+vP1O9K+9vGhoaJA==,type:str]
+          slackID: ENC[AES256_GCM,data:mV2L+F/Yy+qpok8=,iv:ZmmGi8HcBY13ewF0Tfo3Y0BpkdgPOpm4ytmzA5iwpSU=,tag:2hx/R9wsHHuEA3ze4mAlSQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1kkmt80g0cq4uud8gtxwa9p9y4l9nwa2mk8rlqp29sgvkku99evesc0gfsl
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0a3F1eGhhYTVZbGZuWC9E
+            dHZWbFdIM2xYMWRDQkJFWm53NzBIK0xDOUJRCjlHc0J2RWpIanVJd2ZJblBzdXY2
+            K1FxNnlFQ1VYRGhSZmRMakFHQTgwbmsKLS0tIEJtNi9TcFlPTFcrb09hbUNYamZP
+            WTJRc1RkWE1wdUd4Y1I4N1poczd6UVkKm7lsAoOyZhzGKR/X9N0dxH92Qowy7cXT
+            KnFCIgvf8w7Le6j0/IE7VQttL25JZf6V8JB9pn0jOZHAjhhl1sRVfQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1hsll27prywydttq7dtnqtdnu2jpr8zhaulx00l7n4pqmxkhr55vspqmj6l
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDSUF6eEREdWR0Q3hnd1VO
+            eHhsMjhWMUkvYVowSnpFb3JzSExNM3BjK0JVCjBLbjFUMVlOWG12R1BMVS9CY1JF
+            d1VHbVRNKzBWZzBOQWwzbHBTNTgvdjgKLS0tIFkvSUZLdy9aVU02QWxEa01hUmxm
+            dzYrdnBUUlIyOThkT1NjZGFRMHBualEKU2BqAZhh8HQeupskrWpQe+eZq8tY6q+D
+            c8U0PIUv0urIle1LizURUzi7a4G/YrU2QJZIUprSqhkYB4/3um+r6g==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-01-08T11:05:20Z"
+    mac: ENC[AES256_GCM,data:ekriP6l+GSKTMDde/Z3LSvjgDl7rrxnn642K9jgZ+gasOP3HKE8+z8mS6B5sDMF2GhS+zNb+eD3Fhw0tcHu6QVcLFtd2/YefV1bhu/UIjIcgZ8gr4QR4E1S6MOWlIusdF5PgbO+9cRh5PA+rh0LHBp02a8StViL4g1a8zq901Nc=,iv:B3tR8WDVcOTtukcGmyFNiX5DwQUKFi1mYnmorTp+jdU=,tag:8F/Td0v9oAoF4S177rHf0Q==,type:str]
+    pgp: []
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.9.1


### PR DESCRIPTION
### Description:

Taking down the ChatOps app on dev. Changing replicas to 0 and changing image tag to be placeholder for next dev changes.
Also, changing dev secrets to use the Dev Slack App rather than production which is being promoted.

**Promoting** chatops app on dev chatops cluster to staging worker cluster.

---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
