### PR TITLE
change rollout strategy to avoid deleting worker nodes

### DIFF
--- a/charts/dev/capi-infra/values.yaml
+++ b/charts/dev/capi-infra/values.yaml
@@ -354,6 +354,19 @@ openstack-cluster:
     autoscale: false
     machineFlavor: l3.micro
 
+    rolloutStrategy:
+      type: RollingUpdate
+      rollingUpdate:
+        # The maximum number of node group machines that can be unavailable during the update
+        # Can be an absolute number or a percentage of the desired count
+        maxUnavailable: 0
+        # The maximum number of machines that can be scheduled above the desired count for
+        # the group during an update
+        # Can be an absolute number or a percentage of the desired count
+        maxSurge: 1
+        # One of Random, Newest, Oldest
+        deletePolicy: Random
+
     healthCheck:
       enabled: true
       spec:


### PR DESCRIPTION
fully create upgraded worker node before deleting old one. Allows things like longhorn volumes to migrate better
