### PR TITLE
ENH: Add more cloud members to the values

### DIFF
--- a/secrets/staging/worker/apps/chatops.yaml
+++ b/secrets/staging/worker/apps/chatops.yaml
@@ -1,65 +1,65 @@
 secrets:
-    slackBotToken: ENC[AES256_GCM,data:OFHLvslc8fNCNU5mQ+Dp0BWiTPpCUWL/hctbbW1drQ/2OxNzDXU3BRkPqjTjro4ZfoPemPI0dYs=,iv:1KSZVw1HFMZP4hvKnAcjv+VzALOfbRZBJ5gdKE/DW4M=,tag:o4rv9napZc0WBuDzGxrJtw==,type:str]
-    slackAppToken: ENC[AES256_GCM,data:zK72AHtVh/B5zsaomcM3NNhkLrdH16Ju/YVYcEKTiXA+QwYqUb4Ti+etr2wYF3zavYKABheWno5ukOXUgs9RdZNkOELZNEE2AGPJWyIhg/nb1veXEByjU8mt+q+v1AT3iQ==,iv:wjeV+edRXKE9SPuVIn9J7hKK/xjcwogabsQElpbW2QQ=,tag:z5lR6Flz1mZLx3Fm68xoUg==,type:str]
-    githubToken: ENC[AES256_GCM,data:0H1LBLABiLfIIrkpsqXS3U7UpX9S/mG1lo9IQHhCDYtD26R0vOefZmmHQ5jjg3crk3X7PozDGBhR8OY1iVfdln04JohyjOysakjmEukcWb54qop6lbvRK0ok9kDI,iv:ZqKogIeEbvDgTH5RHsP/ACum/zCflDu34Uw/BxbMi48=,tag:uBhyrCiLv0Zk6+lPG1V8gQ==,type:str]
+    slackBotToken: ENC[AES256_GCM,data:fgV5e6ZliyXQDTt2TLCojyvG/LwOxtpEjy+bILeGUIJyseu5+8xJAj6txADMRMChhTOcS7pV3ww=,iv:di0p3+4iyAX3CihxpcMc+g5It8g0J6d9Thm6pg6jffw=,tag:Z1ZdBNAl3Z2dd2bxGBbT+A==,type:str]
+    slackAppToken: ENC[AES256_GCM,data:EW7WwM+lRXGwBCnnE23LhOmiJ6VMQHh3CZ28X4oSsgeznEEkqQriIUDZwOjvKoQ8N85FfQSW2ZumI/SweFvaMPuwyHoMkD6I6CXllRofx0TRSloVXNaRo40/j8tqsC5l7g==,iv:63LHHjYmFxCBqiWHHWldPJoRYfORNSDLIzIprhQPBDs=,tag:KR17Ak0zs3afIhPXccNyZQ==,type:str]
+    githubToken: ENC[AES256_GCM,data:JWW+gV2mhL0cXHkY67OEU4zp3B2BEgnjXXrqhif6NopAEEJ6dFvb/xK5ZqKJR0Yz3efr99ERZfozQoeGFrCGbBPnooUXmY10HqiRLiLVhdBBkyxBedbY/Thl620M,iv:lGdBky+qx17xlVxVvO3h//eR1qwcQmWLSNsIiOZ8YVo=,tag:bwzXE5hK+Hrt33XEKMXB0A==,type:str]
     users:
-        - realName: ENC[AES256_GCM,data:estoQaUU1Yo2FrUsCSg=,iv:zb7dWYcc5Ky1Kf//YwsP83Tpck/frzwNkpGzdQG80aQ=,tag:Vbsw7BpjdDFjfynCm87IHg==,type:str]
-          githubName: ENC[AES256_GCM,data:jmItsDoEWfc=,iv:VNta9ML4PSOGmEXvYwQhlsG1GuKWL5/+d67wDS6xxTc=,tag:ulRO7IU4P0lA9NwMYNr4JQ==,type:str]
-          slackID: ENC[AES256_GCM,data:axc1uG5u1EnG7UE=,iv:u1mYDMilNcvu9IN5VlXqVZj+o5KMM+rvYBu928LitCc=,tag:2qJi1R0vhfU2k+eH6jjsvQ==,type:str]
-        - realName: ENC[AES256_GCM,data:/mji9uCcAZLE9thb,iv:2aF4WBo4CzQWrGIwj7nPZ9olN1PadrnnFrMk6VRso9s=,tag:mD0MxS0MBPVhxx30/CP14w==,type:str]
-          githubName: ENC[AES256_GCM,data:H/wBnJKCVViB520=,iv:Mb2LDPIMRSRbXgGZmme5ifv0ilI9fJRzJ+16JMO3EsA=,tag:Zz6bdqgBHs6q/RG/mou8QA==,type:str]
-          slackID: ENC[AES256_GCM,data:HrNDdUDL+Vrwmyw=,iv:QLwDskwlgOeOG59mK7cVNGkulaOJPv49c9dW782KDdY=,tag:I6/Nh4LE8gGPJMgG7w+/tg==,type:str]
-        - realName: ENC[AES256_GCM,data:dxNgqr6C5//6ABA=,iv:QMLtSQKmfPg5m9uD+qS6jWIh09JfJlj1ESvDhu8N6+w=,tag:zj8rCBUbbSiyKkjcdcNSWg==,type:str]
-          githubName: ENC[AES256_GCM,data:iA7Eu0fhGFI7mulw2A93zA==,iv:u5uCsxQynFuUJ0Sdo6FayUwo90wRk7QaHSlySSBzAbE=,tag:MMV8TB2LtL8fUSPw0wPejQ==,type:str]
-          slackID: ENC[AES256_GCM,data:SU4Ma2mLmCyGJLw=,iv:KsyC4o1KpsoqMWQUSpwKB0IzLfZ3ioKyoDe7IQhys6E=,tag:lbng81cNqS1WCmybCN0VUQ==,type:str]
-        - realName: ENC[AES256_GCM,data:vRuHXo8mWIanAxytnSTD,iv:mLgzgnvj4op4ggql5FyS4bZJiFZofA30yXTI2iVYF6g=,tag:EmSe96fSmoIoYPWkzVKqjw==,type:str]
-          githubName: ENC[AES256_GCM,data:Aa2loIhHqmOKgqExO6Fd,iv:9gYgvIxhsExb0BHLSMV7Jbz4Imxl9hDb9d+pQpGdxHM=,tag:lsp4v1iA27UkTLCjdcLB3Q==,type:str]
-          slackID: ENC[AES256_GCM,data:B3UIrG17vQ3Hn3g=,iv:Q/8DYxm7a9bYFYhSTy3Sx9cSplhBCkwSgmTdv5+qwTM=,tag:1aOBe7pp5NwTlDzlBmvezg==,type:str]
-        - realName: ENC[AES256_GCM,data:CXvbpZuVbr/546FLbQ==,iv:9ae8nCSICkUHQsPsN075ZNMPMIyTKHmeEGbnLbsfbMA=,tag:WWeHFP4FMJvGF7uIwReP3A==,type:str]
-          githubName: ENC[AES256_GCM,data:lJwWyUpMLOg=,iv:dKUvvHj88vqzFLGub6qovUqSygMtrK4KzUX7zl4mZBc=,tag:PQu4nmyndgcuQlmEkh+SrQ==,type:str]
-          slackID: ENC[AES256_GCM,data:OprW2EQPrtZ2iNQ=,iv:U+wWLego3/wYyDmWhOkpyZOustSWz42icSahhBFoohM=,tag:jCDL1bf3kYiyWd6DP6wq0w==,type:str]
-        - realName: ENC[AES256_GCM,data:PO9r//LJ5n+8yQ==,iv:bmhO4z+DTmYsNF0cCXDmS2w6DQQP5vwT6ALFnUkNqLk=,tag:pT8dNT1xKgQ+8iITsjV0/w==,type:str]
-          githubName: ENC[AES256_GCM,data:DZ63yYhoxw==,iv:NcEh+CUAmDH22aCIpE3uJycUKwxanWQI/3vLPRLKcqQ=,tag:DBHSoBYwmqxwFCGmWV+l8Q==,type:str]
-          slackID: ENC[AES256_GCM,data:x2R/1+GwsmC4,iv:3i0IrpiO0gQIprk9/pswwj/dSGSqwuGlxItwSAS5Sx8=,tag:1hDFZJVVelLzl9W9Q6g3ww==,type:str]
-        - realName: ENC[AES256_GCM,data:BNoTEf+bKUfei18e,iv:TNFG22kBn1ha0dcc7EnrMCp4QWiTMvcgVUb4Qr3epLQ=,tag:kq/YzrfDeSUVC5hM08bwxA==,type:str]
-          githubName: ENC[AES256_GCM,data:QmfXQ5HpTg==,iv:BGLmgeIHLQ3iy6oSa9yjQURzO0ZM0u39+eDUNW5c4A0=,tag:FBxPomKZN/dsOZRKNgogoQ==,type:str]
-          slackID: ENC[AES256_GCM,data:eec93Q76fmChgYk=,iv:8+UZXI9BZ+FSqiShIoUACdeQIC8jsNpYNmT2jGUT7XY=,tag:hmNHzcUZ7xWXRxh7ualaXQ==,type:str]
-        - realName: ENC[AES256_GCM,data:mPympaP5zpyuBrL0suuOwCM=,iv:4TNcDe/SbGHof9tUaHjmPejCDhv6JNMFGD2uRSdDDBQ=,tag:rA/193LnLTxPdeKBDN52OQ==,type:str]
-          githubName: ENC[AES256_GCM,data:tkjkBCzcIaxC,iv:0y6QEDND9WRXX6+suK0QMoi77Cbp3Ru9V1PpzzCorGY=,tag:JTEjbvPpF3aevMpRJ7ZC6g==,type:str]
-          slackID: ENC[AES256_GCM,data:x71Q8MTlAPWRLFs=,iv:MdDr1MJezwA9xhhdzpwGiXk0IXhQ32vyUrPKhSW1vP8=,tag:3OjjQRDs6Nlv8DA3bGtXXg==,type:str]
-        - realName: ENC[AES256_GCM,data:HIVgWZ1HHDhsHQ==,iv:D5T/k130/2VC1rtnGF+LK7eJSlYyqn86JcRUjfWOGJ8=,tag:HHzRBMAXOclk4gRLontPUQ==,type:str]
-          githubName: ENC[AES256_GCM,data:j5PQQSvnLhphaQ==,iv:plsQxlrd3nEVyiVjBP4I2OVjnnSLHXOWeAvqgnbebqw=,tag:hmntpdi/0dk/1xkPFX1BCQ==,type:str]
-          slackID: ENC[AES256_GCM,data:8DwMXEDTQNEB,iv:yYo0gBi45oO/qV7Lijpr9cOOxDBkmnty8z9t2hHGgdg=,tag:gqgDj7i8VqEFiuRPk5X2Ig==,type:str]
-        - realName: ENC[AES256_GCM,data:Pm/eawxmUQfjkrG5,iv:xDbatDHrFINlr03uuwkOLJgHOoFEX3Badl1WNJpcpGc=,tag:w0eGLCcwNJ/DYlRiMYgfYw==,type:str]
-          githubName: ENC[AES256_GCM,data:dGbAq8bMWSNqfA==,iv:sS7dvh39zbEPf0LESkoBcM6sykutE5bS8rVLn0wC1yA=,tag:sYz98WcfFcqUkEHkpdB9bg==,type:str]
-          slackID: ENC[AES256_GCM,data:XKlYuhJGn0AkrIs=,iv:oqaTXiUBLVu70cs/f6E4jb8IVkw1mFJOx3HUY8WqQqQ=,tag:xP89t+tDUO6BA6AjoAs5Bw==,type:str]
-        - realName: ENC[AES256_GCM,data:C3vaWMpCFMqlU9g=,iv:GHT94QPaacqj7Dqk4ICNVWax47ABKUeommqTdTdQnVo=,tag:Ljf+5aN5iWW1ooFVlmwRCw==,type:str]
-          githubName: ENC[AES256_GCM,data:UTdWsvn8RT635lZX,iv:s3WxZRGkh77fzeknKzwoswFUGQuV8RyTWdLWBMMvBCc=,tag:qGxLGtrl5s10OnPiMcw/dQ==,type:str]
-          slackID: ENC[AES256_GCM,data:X5T7XL/h0Cy1B2Q=,iv:k0fCLJXN7GvueoYNqEjzhSQ9DP7TJHCw56KBtkNohrQ=,tag:YdUjaCU1HhbTMp9TJDvfcQ==,type:str]
-        - realName: ENC[AES256_GCM,data:z/WVlqm9tn4uYJHxkL/8wLc=,iv:Bd5K/tApNNjk3lxPODG7ToCsbm9U8p82phKs7sCSXoc=,tag:Z5K2lSJloOyg/S95jA7FMg==,type:str]
-          githubName: ENC[AES256_GCM,data:aXbX1Ic/whM94gKNmxmfEQ4=,iv:uSpGH1bkn92pU8TSoJdZfdtx/n2vkyI1aDrg9V4bK6o=,tag:RS1IPgf7QJPHp8hDkMrpbw==,type:str]
-          slackID: ENC[AES256_GCM,data:1T1hykjKS38giZo=,iv:EkcaeNly6/sbAjry88n+Wr/uwMm5mFSJPZFHfOHqGrY=,tag:lF0Nyko5vyWI12rpSSo/HA==,type:str]
-        - realName: ENC[AES256_GCM,data:5lCx348JEUvFhSM=,iv:By7J8HgR/aqVzMJB+3k2XXaGP+K/gGj1RPdVbUWf1a8=,tag:dxcsyU9EOIlXd1UOM7uvtA==,type:str]
-          githubName: ENC[AES256_GCM,data:ony8sQjmSND7hQ==,iv:lTLaQVAVwPxpFa/ktNW6j/XVxDU/5btmF822NOcfhTM=,tag:Xv6z0Inj4HizbQoG6PCfLw==,type:str]
-          slackID: ENC[AES256_GCM,data:yVQ+h+Jbp+SMMWM=,iv:tAJUotbs7oylEHVAmaGTgwzJIu+zLI72poDM8hxj6p4=,tag:6cItmH0x573+4ET5QCP8JA==,type:str]
-        - realName: ENC[AES256_GCM,data:zAf43wceyqeDK0teOA==,iv:ijz3FyukLqH4roxJ9ft33o5Q0oVv9CTqWTtSYS9kb3s=,tag:xGpiO+MjllmVu3BV0RJNVQ==,type:str]
-          githubName: ENC[AES256_GCM,data:sqzt1+tJeFNo,iv:ngTj9UJf4+aJJE+CeHOzTpOJ0AcTl0eNozN6kOaPpLQ=,tag:NxBCWG5eZkpejrcc34FPDA==,type:str]
-          slackID: ENC[AES256_GCM,data:t9br7YDPHifKMMA=,iv:ua2ATmXjICbVxVdlp0T219NogOECVzAI9iByVOs9rMg=,tag:pmchL99+5BwF88BbL+NnKw==,type:str]
-        - realName: ENC[AES256_GCM,data:xTlZ8wGx/CEhtWw=,iv:Fn3vETf6upkCrG+Uj+xYTwc3H7jEL4uwrGYeB6/qBww=,tag:2Jxha2zeg0ZEObD86TInpg==,type:str]
-          githubName: ENC[AES256_GCM,data:7tZyCIyH7rrQYC5R/Lyh9sU=,iv:zCvSirz5VwQ/4XDaNoMPebODzVu4ERDEWFC7K/APmF8=,tag:QHRVJ7X1IwOqZRagKIqj8w==,type:str]
-          slackID: ENC[AES256_GCM,data:JHX0tOD7L6irdCk=,iv:3KYhcQKMuPX3wre1YdItZXeuDzHWyS6elEyUvr4K6HQ=,tag:dqhqZzWZyjpniVWIXWEASA==,type:str]
-        - realName: ENC[AES256_GCM,data:R54/HRSy2H4czQVKBe0I,iv:FQyITp7JK5yHcAOpRdOwSRwnTun513BYGKjN8fEOBRM=,tag:Ba+CtPVAyatQwyb1pmeANQ==,type:str]
-          githubName: ENC[AES256_GCM,data:keET5P5SRpAmspM=,iv:u6HqtsvkAd1SGYpol6+uwYsjF/s2aLXfTYEhyAx0OeY=,tag:5E99P2S9EoYztlmVLGyr6A==,type:str]
-          slackID: ENC[AES256_GCM,data:HkZjNr/pFtEwWTA=,iv:2IkYJTR+Deqf/rxJHfh0C9efawKpx/7hMQk/HdESxH4=,tag:acIZjIS/xT/ULMMP45TIwA==,type:str]
-        - realName: ENC[AES256_GCM,data:rZ6fE/NBjxzy742gmCY=,iv:6JYeWecZeEZR7M2DnA6PCottenj0DYwAUtGzmTgfl+U=,tag:azuJGSJoaKGOMjWfZ92Ghg==,type:str]
-          githubName: ENC[AES256_GCM,data:GpiI82TAmkdZRQ2aEP4=,iv:2CVtm6PYV/ufnVvYNtbsz3mBC7pCH9plqMi6pfXg7RE=,tag:QmQm1JEnXA09WepUyXqYRA==,type:str]
-          slackID: ENC[AES256_GCM,data:DiP3J1Md9L+o+lY=,iv:lw7DruM4hrdG1kJOfbsf8ST1TbPaPXNmLafR+ltOu+o=,tag:lrdUjXYn0SGjqtEvqm4zMg==,type:str]
-        - realName: ENC[AES256_GCM,data:arAYOw==,iv:tV5mMV3GtEZZ5v4wiTo2zIaz2CI5vBESWF+34mIrbVs=,tag:aqgVY7nsCHLRQZCgrxA9zA==,type:str]
-          githubName: ENC[AES256_GCM,data:2vkAMOxu,iv:cx1D8FtW9RqluBBYBLZFW/tYE/lS4xUAZE00KrM/mHE=,tag:akD8MQPpLVqdRT5MGKchqQ==,type:str]
-          slackID: ENC[AES256_GCM,data:YEUeIVve3vY9v64=,iv:QH+wNeqYW0hfX6oSfjVKjIrbk/vxDgoiaoLPbUnKHz8=,tag:2g72V96syWXXW7/JsYfJAw==,type:str]
-        - realName: ENC[AES256_GCM,data:qP8Yd8zyTOBbfmt3YXA=,iv:ocSlTFSFC27eOyOjRKIsZwT1sj8nDW394OWLQjvS+YM=,tag:aLHIDDI24Nm2F3FLP9mdiA==,type:str]
-          githubName: ENC[AES256_GCM,data:bnW36bV2hr5KqOY=,iv:Y+eIG/ZvCNxy1+YHVfoe2Nx7efOONEE1rS6mKa03YN0=,tag:sOjMQBXTVRQ4ULV7D/1/+Q==,type:str]
-          slackID: ENC[AES256_GCM,data:6DLljjqN9GYFR7c=,iv:vj1L9wA8Koi3MQRxVC7yHQ9BH0m+VxYI4QYARmYCF4I=,tag:Pxmopw9o50bi0g8oZTXf0g==,type:str]
+        - realName: ENC[AES256_GCM,data:0F3nfMJAVsth8xPJZ3w=,iv:fV5KtIDftmrgTeqwTkk2jyqoK8mbrAKE3HMC5LMBGzk=,tag:lOiAq4cHArJ692J3hTR1ig==,type:str]
+          githubName: ENC[AES256_GCM,data:+noj7Ifkqb8=,iv:ev5lE/WmsVCmfMrje3I9N01/zAq0XgSTaJ5oEuj+jGI=,tag:WasDMsQSw4ixmqKCq5GSOA==,type:str]
+          slackID: ENC[AES256_GCM,data:kLuJ11+7lMUQrjU=,iv:0WCC8HQBTd7cU4lQ6FJyrEQd7MndvCTFQchEHzl675w=,tag:+sw3oSKXMrwfxhLzaz+x7g==,type:str]
+        - realName: ENC[AES256_GCM,data:XCj/uJz3ATe9G8f2,iv:JHLdd+B5QNX2PVJWnWedLn8qCN2x1kyF6OW04pA4Y/8=,tag:6J/rjRhZUeTkKli1OOM0sw==,type:str]
+          githubName: ENC[AES256_GCM,data:tZxbTYerY0VL7uU=,iv:3XEtiTy09pb2Vwm+kYVdFgDXA/bSko0WyrRJcIkafUo=,tag:m7phU5/UPeMUHI19BUaoqQ==,type:str]
+          slackID: ENC[AES256_GCM,data:Xf4xb7lGGRsd144=,iv:25LtEodEvY3juRXqn5WKNIMyimGmokfU/3vpBBxCt9s=,tag:ps6V63uF2jFPov1GPuGA3g==,type:str]
+        - realName: ENC[AES256_GCM,data:iZVPdSxh13Kb3UQ=,iv:fZAQ7bqyhEOgrzLrEfSoOixitZuIB0P9/G8dPzzuU1A=,tag:JoEobKDilDRGa4SuuMHRiA==,type:str]
+          githubName: ENC[AES256_GCM,data:EApsGN+HcqIQl/d4NDIytg==,iv:SHSrpcvmQKomPP1xmIM+83JOPfspqu/yr8jMAJ7A5+0=,tag:ePMYeDcoFgcx1ld7b08Kow==,type:str]
+          slackID: ENC[AES256_GCM,data:ii89qglXNgDM8Ec=,iv:QOTOjdeZxEQxuyD2D1G/0Ldt2eQiEORBq50z57L8H08=,tag:j/EgMJkF3nIBAPquIWceKQ==,type:str]
+        - realName: ENC[AES256_GCM,data:oQp0lLq97IdlNE9BqhlX,iv:CgqywrSixHeLCUQFfVN/i5R7humZSbNzfaA93HRfwUc=,tag:RYjGmuUdDbn2hGk4+85M7A==,type:str]
+          githubName: ENC[AES256_GCM,data:3rgY5psZIkbsIRGrs426,iv:xEg7kfyb+35xmlD/EfPJBWtxrsLEA+h4EfjmYAPysvQ=,tag:7IGJ0/0P5BnfA4MboF7zpQ==,type:str]
+          slackID: ENC[AES256_GCM,data:ZrSAEN4ijiWMdmA=,iv:cMq7cuTCMyS50wt20GsjtSupkkAFJZa5puoYUEf7J3Q=,tag:E+Q4fLs5QINPTvDJwoSbrQ==,type:str]
+        - realName: ENC[AES256_GCM,data:NcXci5437phmQwkz5g==,iv:8VfJbDBWngXnRMLl9vujaOmjJSJcMfY1v4Bx+zLsFAw=,tag:cZy3uV5XSvtGtkUnLUABCg==,type:str]
+          githubName: ENC[AES256_GCM,data:JXWaKbyZdic=,iv:UUmetytjiSLbMRhFzUOI7eLijS5dmD/NpzR1IMBqxfQ=,tag:4riV6gYYyX/QKkgzppSxoQ==,type:str]
+          slackID: ENC[AES256_GCM,data:p+uZ5UQGmFsMDYY=,iv:ZN5uP67gkok1/082v8baCkkr7D+17kMN1PpMv3ANoMg=,tag:mGqNG858wo5J4Jq2J5u2Lg==,type:str]
+        - realName: ENC[AES256_GCM,data:PcYf1XLp21xC6A==,iv:OcdQDMVtBnYZ/LBs3eNRZ0AacEtlHHDFjqbIRMIx5c4=,tag:y/0Jg0YaTTjsStwpRhZcGQ==,type:str]
+          githubName: ENC[AES256_GCM,data:sauuePd8kA==,iv:p8gCmnYjy6NQPwQ5Q0MVRSNjTTd1vsJUxz+FE9n1dbY=,tag:ChgD07V1FhpfPvbfjuvCtg==,type:str]
+          slackID: ENC[AES256_GCM,data:Rd2vXqae4bU1,iv:YaYxrEVc4AYyTXVuTh1ndLOc79piMT1+Wqn5d+h/HYE=,tag:EuZtH3saQlMSM8LQhBsp9Q==,type:str]
+        - realName: ENC[AES256_GCM,data:GqbNf/T4PjWOvdqa,iv:ar/j3hhAO47eb8kswyp+J+1uRaepo0XYPF6EooQIUi8=,tag:zXHYMvPoD5w+TS37WeF3yQ==,type:str]
+          githubName: ENC[AES256_GCM,data:SyKwNAHnjQ==,iv:6MDYwCcNg4MZfjKZSjRKLOcBxG62gf/w8EQFz601rdA=,tag:g/ezGyJskj57whczuud8jA==,type:str]
+          slackID: ENC[AES256_GCM,data:CjxteEW2Q5GKGEw=,iv:GLFRrBg0vQXSNC/AMj0K937KltylLp43/VVWCSJACTw=,tag:uAC0+Qz+E8oj27IvlsxLaA==,type:str]
+        - realName: ENC[AES256_GCM,data:a/Vq1BVwEnRZeUVtastHw2I=,iv:pCbaLi40AG8WVnp87iWYWv/c2irVYd56QnjpBqFTbCI=,tag:u0fFq3DwSKbqM4ePX5enfg==,type:str]
+          githubName: ENC[AES256_GCM,data:Gd7py+l0rzZn,iv:fVDnBvUvYE1imuAFVtNui/7+hTZdLd2wDV14gjOPh7w=,tag:A5pCYD/jXH9cn3VslersNg==,type:str]
+          slackID: ENC[AES256_GCM,data:/Ooo8BgyMlmrEcc=,iv:IXy5llMsazYF8DZPXy3i1avXxfeC1QDhGeHW50L7bBU=,tag:ea5V1XevbHXxEmx2l73Q9Q==,type:str]
+        - realName: ENC[AES256_GCM,data:ZgcsuzIOzujrmw==,iv:cp+mf+NWSbMp+iJUYLUWhjI96KW8RRSboyPyPuaro+w=,tag:2QpBxAEDId/kfudVo6OCoA==,type:str]
+          githubName: ENC[AES256_GCM,data:/a408znmhJzSdg==,iv:ybxnJqLgC9fA3f7tqfmNf0n5zD4dA5HAD1L/K2R0RpU=,tag:hMI1gxizCdFvz9UUZTwTaw==,type:str]
+          slackID: ENC[AES256_GCM,data:X3bHY1wttu8I,iv:a8/X5PzLHnH5VF26Hz3DhYsiaPlGXD1DIc4zxD/hXyE=,tag:/oZFEjObYYWN3qEe8oyp/A==,type:str]
+        - realName: ENC[AES256_GCM,data:H0jIa1Ba5uDd8Lbu,iv:XpBl3iYZO3ee0fYehCXUNYNS+bzUYzYGJhdHP4zB/cM=,tag:reDRbKozaKbfUevZNOOBMA==,type:str]
+          githubName: ENC[AES256_GCM,data:R9YgoAZqBZOdWA==,iv:Irfymbwrq45kQ+tSIrFERaFor4TyXrePYufGcHafZU4=,tag:4xnwMmH0TSpIFeIt/8Qmrw==,type:str]
+          slackID: ENC[AES256_GCM,data:fz1hHvxyl0PdjNw=,iv:tlVK2NJrBExzxzHQB4V8MKNU9B+/ITvPbandpJ26DKc=,tag:e8u5UiR8NQ2Rbu9EI+cKXA==,type:str]
+        - realName: ENC[AES256_GCM,data:TE2u0i+QeAmK2JE=,iv:ezNWxoRk4a+BW7yqhA6EtE76Po7651t6xtWGxgQrtL0=,tag:AbZ3r9x3ZW7NvzMv81zDHA==,type:str]
+          githubName: ENC[AES256_GCM,data:ThPrkbSHFzoqHcri,iv:1mSC6eRKv3JRkQPSQcD5SDMvngZG8iS8yB3mymYTqG4=,tag:tcQYXxt5gUDWo8ftDdRqSA==,type:str]
+          slackID: ENC[AES256_GCM,data:TL26SkJm62RWVFU=,iv:ndTk2VvNmOfCn9B1KJL5LI/ZiLDb8FhC3bzVIBgYqUc=,tag:M7ktenN3owJ7OEiETW+Q4Q==,type:str]
+        - realName: ENC[AES256_GCM,data:sQ+XumEfcHA3gsE8pFP+iAQ=,iv:1nXxlUAlAbg/OkP6R926Od1vtHvTg1foVY1BLFAc78A=,tag:VylHR4T6FgZIXK8KX7dazg==,type:str]
+          githubName: ENC[AES256_GCM,data:rZ1F0spr5mX/HsCiqVIaDGA=,iv:Pec8fyU3LiBA52XffQFd+MOdgthQ0KRm1SWpGunpwfg=,tag:5HLapgNpgzHKN/cVnXcxcA==,type:str]
+          slackID: ENC[AES256_GCM,data:yC14+Z0IscQRIwI=,iv:8fq8hAfnQjChKfr2WQvc/L+LZbhGfXSw8q7RTNaUEYQ=,tag:LftGoxXZi7U+lGmGdYY9pg==,type:str]
+        - realName: ENC[AES256_GCM,data:Gao3VFBJi/o9UOU=,iv:Axsr6xE3Xq1EfIUMvh89bNhHPtWksX+nYUG+DeWo4n4=,tag:Y+WbJA+QLKyZUuHtma0aKQ==,type:str]
+          githubName: ENC[AES256_GCM,data:lf6UtIlBhXmQZQ==,iv:In0py1ZvAkKPbjrvVWQG+ppkcGH0A4P/on/ZxPX99hA=,tag:AFd7U/KwYG8axqnYDdt6Fg==,type:str]
+          slackID: ENC[AES256_GCM,data:kWZrGafzN/f8iGY=,iv:H4FQuCEDQ5scxA10l+WXAcyLTMoKGiDkrMhFtHMCso4=,tag:eFPl/x/oIs8rHJNSfhdImw==,type:str]
+        - realName: ENC[AES256_GCM,data:4my3tvmz9APmdbbZ+g==,iv:sSQLWgE9hlXUvCBsI12ZYqqZ1WPBMl9NfC0AIN/+6RY=,tag:weNKD1BBcrwEN0P4ALJjgA==,type:str]
+          githubName: ENC[AES256_GCM,data:uXy2yhPm0TwE,iv:lddZWP9euVP4CNVI3mLWGSMUfq6Bjxy12ZMDlgHSjSs=,tag:5gNten1UCg2oJ9ePHcurPQ==,type:str]
+          slackID: ENC[AES256_GCM,data:oYdF6SpP9nWYYY0=,iv:SEO8ZJymnSyAOIo0YraBA46E+1EYhEomTgQ44aoTSkU=,tag:bOElAEGM5EvSeuchyW1H6w==,type:str]
+        - realName: ENC[AES256_GCM,data:U59tEq35jzV2I6M=,iv:w3p+/R2+aQUuu8rr+dfNvUsH8TwP6HbYH4XlsgB9aww=,tag:K0lg9jMM4vyx+1Bl8fOsfw==,type:str]
+          githubName: ENC[AES256_GCM,data:XEiNcowWRzrVKROszgUhKZA=,iv:8Rvs3rQOzTjvEVB6U9r8pR7+3tzgr4JnQMtWCwY8Vtg=,tag:KqFt7RdYDf4RPfqWlcGunQ==,type:str]
+          slackID: ENC[AES256_GCM,data:D+ej7H97iawXDMw=,iv:QM+Sh6tougBZ5sYkH8qMH3yw61G9u/7kROBaZwDxLZ0=,tag:ikJYWeFW24ezcXiVN+8QRQ==,type:str]
+        - realName: ENC[AES256_GCM,data:7DtNat8gQtJ3j4q66RTY,iv:IWq8uBxd7M5n2vuhGojC1P0i985NQeMDjisFhxDLoc0=,tag:wlKtsQV2vpOr6CbhJs/vQw==,type:str]
+          githubName: ENC[AES256_GCM,data:C0G9h6cY+JHHbXU=,iv:TTpz+5R9Qy4glAtr9SwECZFuKOpdvyoYPimG5buK580=,tag:8IQdXA2MeCSmz16PN/tEJg==,type:str]
+          slackID: ENC[AES256_GCM,data:+HZeLSFfqpQBuNM=,iv:u8Jvyf0YXAunVgi5He8k36oCk4+bcHWg0W7+w7M+wPs=,tag:EwUXVYff2fFMcXXXgG99tQ==,type:str]
+        - realName: ENC[AES256_GCM,data:bM2q2xryAqOAuN0C5MM=,iv:wHqwmWMlKoiUzl6AK+5sLR3ZxKmxLNCBj4YDSqXvEqs=,tag:gHIt4avnwb1dZaRO8+7c6A==,type:str]
+          githubName: ENC[AES256_GCM,data:1T4GY7gyaPp3hnXdNCE=,iv:uUWI5R2O/pOiqMuaqzel6nNMWIdYvX3nP0/3zY+9hNI=,tag:M/nY9ozPbKLimZH3Lp6Lhw==,type:str]
+          slackID: ENC[AES256_GCM,data:iQgYg87Ush4i1mA=,iv:cs9pKK0EQmM7UBhXuYMd3lCNO5hFgVvOKI8ZbCIjG4k=,tag:3YpCFM67qhyC6zULYPjvNw==,type:str]
+        - realName: ENC[AES256_GCM,data:SUL+rA==,iv:Bx/g2HfufBtf6lzMEBsY7xKbOun4xORQQnYiIGicQsQ=,tag:xNyCh+9+x5aP07mQkN70QA==,type:str]
+          githubName: ENC[AES256_GCM,data:InT4j6dQ,iv:LyjqV22di9k5co9hJlTKyl70Ic/eQDQ6z+GojSsYp+Y=,tag:6JnHmO1fo/lEZ7i/bVKP2w==,type:str]
+          slackID: ENC[AES256_GCM,data:XcqoJffDN73usbI=,iv:/rZTRHvKFegW6QNVtyg7qBayWKywYmksfflRpbTi3dE=,tag:LgfXZkKlSJ893zuPV3JTVA==,type:str]
+        - realName: ENC[AES256_GCM,data:BxYp3j/7EOZk3TSl99M=,iv:XtpPHL24gcYsZ7JpjXRmkh47p/ofn5f6cjF6wJ6LkxI=,tag:DmVcCx4v8gJRoMqzD20GQQ==,type:str]
+          githubName: ENC[AES256_GCM,data:p+fGDnExISBVdWY=,iv:imATuD9x/mwi62xZyUbtAsF/gDvTLf+C1aATKN3troM=,tag:xXjZu2CLV8f7jimNZU9hlg==,type:str]
+          slackID: ENC[AES256_GCM,data:Dg9t6pugn2jN6xI=,iv:LoenzUwviu3zdBmGKhuJdvyGW1TVb/W137EhtHAZhl4=,tag:31xlk+g9hThHBTswaiFAYA==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -69,23 +69,23 @@ sops:
         - recipient: age1kkmt80g0cq4uud8gtxwa9p9y4l9nwa2mk8rlqp29sgvkku99evesc0gfsl
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqREt5eFFBRTJMempwczRJ
-            SU1MdW9ITUpZdGxXQjVHcmZlZTBWeEpQakhjCkZwbWFYUWcxUElpZkNKWGVOVEpw
-            VmtjdFVPemYrM1VPaVBrVUhxazRpZ2sKLS0tIENqRWhYYmVmLzlQTTVSUHJ4NnlS
-            S1pvSmtSZkJRdmhGZFNZZEczeUhtMG8KsvQ11xgKvvu+pi5hSH34GcHHqn316Yrk
-            Y+rAMC/QsUY9FQR7LcE5AiNapPue3ToihCYN8nmGMcGlZ84kdQLPGA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtNVp2R2dFcDhQTm9WQjJ0
+            SU8yRW54cFJlRjVKRHdhYzh5ZDAvZ1JMQ21ZCm8raDBQNDFpMjRQenNrSlBMYXky
+            am9CNGpLTzIwYm5Idlk1bzN4SFBMVlkKLS0tIFJJcVBBa2VIM2lNY1JFQk85cVhP
+            dURwMEF0T0xFSDJCbWFtQzdXcXVraVkKViUdUw3bfQZiLZ+157M9MoWEWMyWuaZO
+            SHt1DPv4NmZCPGuLTfkWgeaI8rgPaNBkmR4cCHnSMbtX3yciSxBruA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1hsll27prywydttq7dtnqtdnu2jpr8zhaulx00l7n4pqmxkhr55vspqmj6l
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvUHNSYU9FMkFJQzBlQzZh
-            ajI4TlVWL2YwNUg5VS9PUzVwZy9ndHU1bEJRCk5Ja1V2M3p1RUpoWGtRNGM5Tkpy
-            ZDc2eklVRFVGUXM0ekNIY3Jxei9UVGcKLS0tIE0vZEMzVVBFZlRtUWNLWkxKN0d5
-            Wmlla0EraUxIWWczenhsY3NMNjJqSWsK0BkA6nc25pQxkNU0pxYBZJ0f3Kg5AvV5
-            ptAACwLxuKbiCldMrgdZqoPoif7X89iwghMDy16l8vyKS27q3DmFdA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlLzJwbzJLdXhrY3hGUUtY
+            d2lXbGtqZXRvV25JZ2Jac25oa0FUWTJkREI4CkdUbGdWRVQ3MG9MN1FwQ2VDT1lz
+            emhBQzZmYkZqUGgrNkJjeGtqb0lTNmcKLS0tIFNkM0xtNFhEVlJ1anNjLzlaWm5i
+            NmozaWpSSDdKQTk1UEVacThVZXpqRU0KygStCPH62BVt4JoFVuxOCoe61uDeQa/V
+            C3lCQ4iKYXYlAoSqyIOqJYMOjCcK00Kvm0hTuf6/LB5V4zi3NlqmVQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-01-20T10:04:40Z"
-    mac: ENC[AES256_GCM,data:q/sSf70JjT9Q9gA5YiQUwulXGy8mpz2Ewf/YD2WuwYx3OhXYGHtTq1ZzUmCoCDmDmm6SNiOBb2gc6Lwh/rlcB4hqK7iRLs2db0OnttxEoxhfsMhy+77J594Uzp/c7b5ybM0q8FfXDdWUr3g83xBnGhtJ2JPGIhESnLqBaWbWlDY=,iv:5sIOEKPgWNIdavDT3CQXvo/SZlM9SDyBtNgfRfJmczo=,tag:doeASmEz9TLs1ZI9xqBFsw==,type:str]
+    lastmodified: "2025-01-29T09:50:44Z"
+    mac: ENC[AES256_GCM,data:mxUFUsxtFDKrlrhzLwWLsfPX6MmNczz8WZj7wDwmTwFFR6hwU1k1/OQH5diojYPi1ODYYy3KjyWJN/XrX5hMROa1cpd5cmej4GEfXuB4a6+KHZ0McolD341ued8gW6XjtgKHKu/ieZWhJs4sSAExsTF4WntX/eO0A68EIxANxdE=,iv:yd3x7oW5oevvhUM9UQOeeBsTGT2c1t/fAxQ3a7dGS+w=,tag:5CAi9lJmkDY3oKULuZX6Zg==,type:str]
     pgp: []
     unencrypted_regex: ^(apiVersion|metadata|kind|type)$
     version: 3.9.1

--- a/secrets/staging/worker/apps/chatops.yaml
+++ b/secrets/staging/worker/apps/chatops.yaml
@@ -1,56 +1,65 @@
 secrets:
-    slackBotToken: ENC[AES256_GCM,data:lkhae/vGb4JoIFCDg6yqDUuzIXH2U+kNalrGoK4bQqGy28V19GneVBJogxduVBSwyu9/QP19dRU=,iv:0aoihr6cLCNVNWiVv4BRwkLXAI1Xd0zo7E95Firvqsg=,tag:+VqJSpg/b+SBS3U6fULXQQ==,type:str]
-    slackAppToken: ENC[AES256_GCM,data:MYUC/qk959Wxb+T+3ZOySMG1AjxtF2/sfi/SNbF2jqDWmgHW9+olXClnsVOMNP8KxXVLtTLBMY1KpXru1SyavPGayI5nQ4EG9/KxUkpIrpXvftHGHjuAUID7X0283NP1mA==,iv:VJ8tVMciYObvxv1fed1UK7+rwMHkpNehJ36EttKc/Wg=,tag:fGVDmW6fpveK3t4EqDWLoA==,type:str]
-    githubToken: ENC[AES256_GCM,data:i29CkGgqufeCurXJ2/+KegRVlhElCrhyTGaRV2kO+aUS8kYp9VydPntpKpJ5x0NvIWo6k5ljhadoy2xzNvAWTZU3roT6pRxw4nLlTdfP74j412UTjrC6EGkoI0oA,iv:bXGy6K6nO2QfSneqr8IIh16CyrArwO0uxdcEgr05dV8=,tag:gBOk0/NcfMHFrLFamPrEJQ==,type:str]
+    slackBotToken: ENC[AES256_GCM,data:OFHLvslc8fNCNU5mQ+Dp0BWiTPpCUWL/hctbbW1drQ/2OxNzDXU3BRkPqjTjro4ZfoPemPI0dYs=,iv:1KSZVw1HFMZP4hvKnAcjv+VzALOfbRZBJ5gdKE/DW4M=,tag:o4rv9napZc0WBuDzGxrJtw==,type:str]
+    slackAppToken: ENC[AES256_GCM,data:zK72AHtVh/B5zsaomcM3NNhkLrdH16Ju/YVYcEKTiXA+QwYqUb4Ti+etr2wYF3zavYKABheWno5ukOXUgs9RdZNkOELZNEE2AGPJWyIhg/nb1veXEByjU8mt+q+v1AT3iQ==,iv:wjeV+edRXKE9SPuVIn9J7hKK/xjcwogabsQElpbW2QQ=,tag:z5lR6Flz1mZLx3Fm68xoUg==,type:str]
+    githubToken: ENC[AES256_GCM,data:0H1LBLABiLfIIrkpsqXS3U7UpX9S/mG1lo9IQHhCDYtD26R0vOefZmmHQ5jjg3crk3X7PozDGBhR8OY1iVfdln04JohyjOysakjmEukcWb54qop6lbvRK0ok9kDI,iv:ZqKogIeEbvDgTH5RHsP/ACum/zCflDu34Uw/BxbMi48=,tag:uBhyrCiLv0Zk6+lPG1V8gQ==,type:str]
     users:
-        - realName: ENC[AES256_GCM,data:n5WaujbWuZy15G2u0UU=,iv:eHUW2+a2/BEuNa2lurbtpW0W9fLSJjmfGd1SlOMFX9M=,tag:rGo6DbsSbJp7jp07POQPNw==,type:str]
-          githubName: ENC[AES256_GCM,data:deHenZQHC1k=,iv:GFt19VI4w1RzYtLvAaeXyLL7T/yortMrRKd1lUZKXZc=,tag:mLvXNk5km6VgzzD9vKeSgg==,type:str]
-          slackID: ENC[AES256_GCM,data:x/BGi2H6mpLylVs=,iv:nOQZ/vt3pyTpIfXe5uTbNdLurGkVAu7lGA6Uvu7cUk0=,tag:FvNtOEEegwgSNowioNY3pQ==,type:str]
-        - realName: ENC[AES256_GCM,data:i+Aoko8c/i8Xxvt5,iv:o/xThrGGNxSAUZMlSx2lKQM9pc5p+IIF06W/+HDquOg=,tag:MkT5XIhBNDCkjQKvfUZWtw==,type:str]
-          githubName: ENC[AES256_GCM,data:ZV0tu5RlcNxCPZU=,iv:A83ioBwgOidscdvTS/3qzrE223hMOaoJISwtnUMGk4s=,tag:HNPT8ugqcxvn706fgQxkuA==,type:str]
-          slackID: ENC[AES256_GCM,data:VD+svxD/zRloc3k=,iv:uU4Y1WlnFHl6S65t1HWsFLeg/sOOb8DXe+/LUYMp2yE=,tag:Wdi3EO83CTmn/EJymnMtFA==,type:str]
-        - realName: ENC[AES256_GCM,data:Gy5WxohTyTrqRdo=,iv:+SmofiyhGqgIknNiHrqVqW1SoN8OVkxpkmK80EAqKfM=,tag:rv6nDPVH0eEkl11A42PI1g==,type:str]
-          githubName: ENC[AES256_GCM,data:d8CW5uufzAR0uU59ONt9UQ==,iv:JTjj9qqbtfWbxy5fR1Z/JAvxK8981+0yFwEqdesfgLk=,tag:Yq9oH3legkeRErpS+97O7Q==,type:str]
-          slackID: ENC[AES256_GCM,data:7S7CjqHJFEqZqv4=,iv:KayNrZ8cMIJyu1FFuavjMKMyA50p9I/fXs/w5gMbCNo=,tag:nk/GGLHF47ly2VrxkrMC6Q==,type:str]
-        - realName: ENC[AES256_GCM,data:KHZOmOYifIrvhIyBx2kO,iv:/xCjgf5m/c52EKKRn83lGgdQEK8vbvKLlZO9rKP3AoA=,tag:fGpKRoXosZWrzRthox4Pzw==,type:str]
-          githubName: ENC[AES256_GCM,data:yZaLBg61D+2gCL95gkI1,iv:xhA1tzvuUTxKDQLYF28yZWMbvj9XLPkd9sKGCc/MIkE=,tag:H5M/qKjthYMSvOxEjwOhow==,type:str]
-          slackID: ENC[AES256_GCM,data:LyzKyOvWJA44HaA=,iv:JV+69jyY2D2C1HO3VvB9q4XsAnnEj9K1wiM9hKDvzRw=,tag:M5MH9UCFVor1bwMO7SBCSQ==,type:str]
-        - realName: ENC[AES256_GCM,data:3KtDKa2snwAUcOzDRA==,iv:PvKxbA+NEv5bVauSSg9c98p8/Vp+uFhiJkyjakPKoaU=,tag:O8kmJoTJWcJkGjV+8BPeLQ==,type:str]
-          githubName: ENC[AES256_GCM,data:T50syLhCiAs=,iv:AN5uu7ZtJUIVniKsh4ubYG8pD4De1bsHTz0r6FtZyms=,tag:ITczaaZ42lWnzqheiHUV2A==,type:str]
-          slackID: ENC[AES256_GCM,data:Mo5sdAZ22kvybgY=,iv:zoKe0PdB22r/MtsGAqvlfkz3navfzEeEaUPl1neZDs8=,tag:fglw9BwfMHkYUB1z5dA6ew==,type:str]
-        - realName: ENC[AES256_GCM,data:3yqk1bmv4WJgNA==,iv:WAe3LefMuoUr+3oxiGWlbxQmNtURWy4+4pVKP/fhbOk=,tag:e2A8IQYhHguLSOghZNmo1A==,type:str]
-          githubName: ENC[AES256_GCM,data:sOj78svqng==,iv:k6HftaViiISgSwLb9jXli45TBPDCWEAFMz9YBda6qWg=,tag:3Rxs1J93hc0vrc6H0g1sDw==,type:str]
-          slackID: ENC[AES256_GCM,data:+9FdBXZgfpAo,iv:Mr9cPHfOT0HPExLEFei2b0/2MpcpeYHCmYziYrjDLD4=,tag:nrGLUMSneWWqqX2LyHG+yA==,type:str]
-        - realName: ENC[AES256_GCM,data:EWxm630TyOdgfOGe,iv:1ItMAoCmdLQZQ1OY1jqsuwBa2c/xk40ldazM+IjVFwg=,tag:vDCforCvsYKATVqJM7JqsQ==,type:str]
-          githubName: ENC[AES256_GCM,data:xOUeZBcGcw==,iv:C/UB2MWP4aU8cCjUJuPGtQBUUZ2W7PQblaiht3q9go8=,tag:/2CV7893rnPeVPKVwERPBg==,type:str]
-          slackID: ENC[AES256_GCM,data:z9V/RvM1tyIvRgc=,iv:wHLjo2XjBmYyjFSssWoXX/gNRmEk0p4TiLtxmhceSuM=,tag:9+ZbrGohJJfVP594u34jgQ==,type:str]
-        - realName: ENC[AES256_GCM,data:V8EkUJpaGGsR4zk691aXBhs=,iv:nHfAWktpt1UUIcVIB8H85lPWO4Mi5qqXhchilhLo75Q=,tag:D/3/2UKXgWfKvh0GEA31rg==,type:str]
-          githubName: ENC[AES256_GCM,data:9yyRbJgghaJ4,iv:iD0R3uN0Ay1HCrlizF/RJjoxxuHRpAnp4PgWXj/JQQ4=,tag:3lHaca6CUW7ywpveU7JTyw==,type:str]
-          slackID: ENC[AES256_GCM,data:ho7iZ+sJtPzswEE=,iv:3iUCNbS8BySzmVDORUMqieS69grCw3UCqEdLvZzZvbk=,tag:Yz62DtqvP1YUkKmTCEgLpw==,type:str]
-        - realName: ENC[AES256_GCM,data:FNx57cxSakulKg==,iv:/OhznIaxf39dmqlpFyaAhg7pyQsCzOvWJQ3bfxXZSmg=,tag:F1iXwRwlJ7U3TAodgULzow==,type:str]
-          githubName: ENC[AES256_GCM,data:ctbSgn+NmB++gg==,iv:/BpVDuKkuqx0i0pVPuWgZlDe2+eV+gVdbdy45csSYI4=,tag:okcUrCZxI8O5iqGdAwCyTw==,type:str]
-          slackID: ENC[AES256_GCM,data:R+6OpaL6T+To,iv:Ln7Ba29MxOw39uEC/psxMLW0lO528RO1j9ng2PStlHE=,tag:jOVY3PSVoYFPQK77F9NldQ==,type:str]
-        - realName: ENC[AES256_GCM,data:gHE7ZnaKD9UB6QzA,iv:X2C4TMHFHdzIwlHgoGZpzf6bm6ROyKRiItrMEAWET9U=,tag:SY+uhpdpvVUJWpdvrFv07w==,type:str]
-          githubName: ENC[AES256_GCM,data:Qed8S9EIacCPHQ==,iv:R1Q9XJDQda18vOhwHkkZfCDyUQ55MjWAE5WKRbXFiA4=,tag:yksdrf8Z5CPxYsn2uIcr9Q==,type:str]
-          slackID: ENC[AES256_GCM,data:/zbdzthEOVnpglY=,iv:V83XxGjrzuhO6gGjJxENqsfRoliLaZyJHVNsSM3pMmg=,tag:feZfzbdWF+N3yqkRudBH9w==,type:str]
-        - realName: ENC[AES256_GCM,data:cER9rF4KtkveHl8=,iv:6JPXeNI+fI677KRUc2zqPOQKK5dZE/kd/GigLEBPrAM=,tag:GFYsV5VJJUPcaCCAOK/EqA==,type:str]
-          githubName: ENC[AES256_GCM,data:Rlhlt3Xkydg2aE3+,iv:sMczGxWO0m0JjrOSq7oHz3dj4yWcZzO2u4to1gxnLK0=,tag:wW2pVlrHoJAlGlhRMj6XSA==,type:str]
-          slackID: ENC[AES256_GCM,data:pPHKn8+NBSQEW94=,iv:GNK9rhuhpkjPszWWk+w9pA8kpGsrP8mh87kCPh/I+dI=,tag:xr9YMtA1r4GQbluV3GD7jA==,type:str]
-        - realName: ENC[AES256_GCM,data:vJ9VQ+X3Dmew2qFmqS5quPw=,iv:zV6xMWo+IHCCe+oNtOzrSQxsKF0DTbtd3GXOBpLQig0=,tag:fblMZ41Y2TSK+cNmNkIpyQ==,type:str]
-          githubName: ENC[AES256_GCM,data:OTIKw4Lk+3h3X+FejClIZrM=,iv:awqMlEv6ESnZ+KEGowq16/FhpSU6tphyag6AOAwR4Z8=,tag:UvfPewXJb4GjNffQzCaDbw==,type:str]
-          slackID: ENC[AES256_GCM,data:dYk9EJm3/et75kg=,iv:6ixtXTjOniqf7mK8rwHaKgwqcMc7s08HfIxq9QAJ84o=,tag:3q9SVMXS5e7qxqU9bN2fVA==,type:str]
-        - realName: ENC[AES256_GCM,data:IV7pT3Rf8V6f5i8=,iv:BllqXqMO0zeNG/2OANUWNjaYRyh/Bg04L4RFq+ZB9T4=,tag:V2pxHXu5MUR+uqhk6sC2ZA==,type:str]
-          githubName: ENC[AES256_GCM,data:wUgk9QIrEcI5AA==,iv:ZZ3gtA5bpG/5V4YSlbKOVFdRUyA8dMuCEokIEsNMP74=,tag:XmCfTFcS/U8KYyRfY9RKyA==,type:str]
-          slackID: ENC[AES256_GCM,data:Rrsndvn2y0xJ+fU=,iv:/Kd9fFNZqgBNezoY/a5JbCeHF9QCM4azcL5n/NsJu8Y=,tag:awsZspgH9KjbHNG7luirOQ==,type:str]
-        - realName: ENC[AES256_GCM,data:jFEw222ifw3UM97ZUA==,iv:89UyzjxZu4hZVVQimecHID6YEZUwtxrOHJaBzU/T3vs=,tag:opuN7rY0+s9fBkCGGtW5GQ==,type:str]
-          githubName: ENC[AES256_GCM,data:oMid5g8KYUAK,iv:Qr+qgU9xS2/AkbvXE0Zh3H9XWsqHsceyDR6IadOlQCs=,tag:JceK5h7oWfYEAC6XT3XDYQ==,type:str]
-          slackID: ENC[AES256_GCM,data:ObcIW7hturRcYfQ=,iv:Zir95goNvQ0kFEIxCLDOdndIbVUZTIBbEt3lwDo0F1M=,tag:TMIk3meLIOpxXfdOGB5a1g==,type:str]
-        - realName: ENC[AES256_GCM,data:ws4TiErVRkx1JU8=,iv:WvcYIgjN8XL7xWGxeN/6f6aQMADi8FKiSs0li5qDjo8=,tag:pm1Mxucaav5n52dgILQ3Bw==,type:str]
-          githubName: ENC[AES256_GCM,data:oq3sIzfUAYsAhl+Ue8lUc9c=,iv:WJWAADTLzZsYaKivFGQC86IMlktmc2GyzZBjGqtYvVU=,tag:vqwWqgEQsYNTBoE7Iql2iQ==,type:str]
-          slackID: ENC[AES256_GCM,data:xL78fgydV75DEyA=,iv:J24/GREzcYQ9GleZR/6gqpOE+pfMI8sTBXAC/ydlqAA=,tag:aARmn17UhFyyAnB12r5ZWg==,type:str]
-        - realName: ENC[AES256_GCM,data:gJ8MVuK5wg6ESjz5Sxjm,iv:vufu4tXcbPbIxadR5QZ9f/B7ZxUB98FgtP0FjKlfuvE=,tag:l1Bj7omNrBpFLF0PEcQMHQ==,type:str]
-          githubName: ENC[AES256_GCM,data:+v5g80WC+3wzaT0=,iv:u1uE8if6ZFx4mcLvlTvg6iEuxb9y52oM1kbygZcYjT0=,tag:lYbWMdMBsVnQAPNEM1kriw==,type:str]
-          slackID: ENC[AES256_GCM,data:xoNFcVbzEjMNHDU=,iv:qu87mh6BhLjSQqMbIfPykjurNY5ffzWIuq/sE16k76Y=,tag:Y6Af0d33ehBYez0okwmzwg==,type:str]
+        - realName: ENC[AES256_GCM,data:estoQaUU1Yo2FrUsCSg=,iv:zb7dWYcc5Ky1Kf//YwsP83Tpck/frzwNkpGzdQG80aQ=,tag:Vbsw7BpjdDFjfynCm87IHg==,type:str]
+          githubName: ENC[AES256_GCM,data:jmItsDoEWfc=,iv:VNta9ML4PSOGmEXvYwQhlsG1GuKWL5/+d67wDS6xxTc=,tag:ulRO7IU4P0lA9NwMYNr4JQ==,type:str]
+          slackID: ENC[AES256_GCM,data:axc1uG5u1EnG7UE=,iv:u1mYDMilNcvu9IN5VlXqVZj+o5KMM+rvYBu928LitCc=,tag:2qJi1R0vhfU2k+eH6jjsvQ==,type:str]
+        - realName: ENC[AES256_GCM,data:/mji9uCcAZLE9thb,iv:2aF4WBo4CzQWrGIwj7nPZ9olN1PadrnnFrMk6VRso9s=,tag:mD0MxS0MBPVhxx30/CP14w==,type:str]
+          githubName: ENC[AES256_GCM,data:H/wBnJKCVViB520=,iv:Mb2LDPIMRSRbXgGZmme5ifv0ilI9fJRzJ+16JMO3EsA=,tag:Zz6bdqgBHs6q/RG/mou8QA==,type:str]
+          slackID: ENC[AES256_GCM,data:HrNDdUDL+Vrwmyw=,iv:QLwDskwlgOeOG59mK7cVNGkulaOJPv49c9dW782KDdY=,tag:I6/Nh4LE8gGPJMgG7w+/tg==,type:str]
+        - realName: ENC[AES256_GCM,data:dxNgqr6C5//6ABA=,iv:QMLtSQKmfPg5m9uD+qS6jWIh09JfJlj1ESvDhu8N6+w=,tag:zj8rCBUbbSiyKkjcdcNSWg==,type:str]
+          githubName: ENC[AES256_GCM,data:iA7Eu0fhGFI7mulw2A93zA==,iv:u5uCsxQynFuUJ0Sdo6FayUwo90wRk7QaHSlySSBzAbE=,tag:MMV8TB2LtL8fUSPw0wPejQ==,type:str]
+          slackID: ENC[AES256_GCM,data:SU4Ma2mLmCyGJLw=,iv:KsyC4o1KpsoqMWQUSpwKB0IzLfZ3ioKyoDe7IQhys6E=,tag:lbng81cNqS1WCmybCN0VUQ==,type:str]
+        - realName: ENC[AES256_GCM,data:vRuHXo8mWIanAxytnSTD,iv:mLgzgnvj4op4ggql5FyS4bZJiFZofA30yXTI2iVYF6g=,tag:EmSe96fSmoIoYPWkzVKqjw==,type:str]
+          githubName: ENC[AES256_GCM,data:Aa2loIhHqmOKgqExO6Fd,iv:9gYgvIxhsExb0BHLSMV7Jbz4Imxl9hDb9d+pQpGdxHM=,tag:lsp4v1iA27UkTLCjdcLB3Q==,type:str]
+          slackID: ENC[AES256_GCM,data:B3UIrG17vQ3Hn3g=,iv:Q/8DYxm7a9bYFYhSTy3Sx9cSplhBCkwSgmTdv5+qwTM=,tag:1aOBe7pp5NwTlDzlBmvezg==,type:str]
+        - realName: ENC[AES256_GCM,data:CXvbpZuVbr/546FLbQ==,iv:9ae8nCSICkUHQsPsN075ZNMPMIyTKHmeEGbnLbsfbMA=,tag:WWeHFP4FMJvGF7uIwReP3A==,type:str]
+          githubName: ENC[AES256_GCM,data:lJwWyUpMLOg=,iv:dKUvvHj88vqzFLGub6qovUqSygMtrK4KzUX7zl4mZBc=,tag:PQu4nmyndgcuQlmEkh+SrQ==,type:str]
+          slackID: ENC[AES256_GCM,data:OprW2EQPrtZ2iNQ=,iv:U+wWLego3/wYyDmWhOkpyZOustSWz42icSahhBFoohM=,tag:jCDL1bf3kYiyWd6DP6wq0w==,type:str]
+        - realName: ENC[AES256_GCM,data:PO9r//LJ5n+8yQ==,iv:bmhO4z+DTmYsNF0cCXDmS2w6DQQP5vwT6ALFnUkNqLk=,tag:pT8dNT1xKgQ+8iITsjV0/w==,type:str]
+          githubName: ENC[AES256_GCM,data:DZ63yYhoxw==,iv:NcEh+CUAmDH22aCIpE3uJycUKwxanWQI/3vLPRLKcqQ=,tag:DBHSoBYwmqxwFCGmWV+l8Q==,type:str]
+          slackID: ENC[AES256_GCM,data:x2R/1+GwsmC4,iv:3i0IrpiO0gQIprk9/pswwj/dSGSqwuGlxItwSAS5Sx8=,tag:1hDFZJVVelLzl9W9Q6g3ww==,type:str]
+        - realName: ENC[AES256_GCM,data:BNoTEf+bKUfei18e,iv:TNFG22kBn1ha0dcc7EnrMCp4QWiTMvcgVUb4Qr3epLQ=,tag:kq/YzrfDeSUVC5hM08bwxA==,type:str]
+          githubName: ENC[AES256_GCM,data:QmfXQ5HpTg==,iv:BGLmgeIHLQ3iy6oSa9yjQURzO0ZM0u39+eDUNW5c4A0=,tag:FBxPomKZN/dsOZRKNgogoQ==,type:str]
+          slackID: ENC[AES256_GCM,data:eec93Q76fmChgYk=,iv:8+UZXI9BZ+FSqiShIoUACdeQIC8jsNpYNmT2jGUT7XY=,tag:hmNHzcUZ7xWXRxh7ualaXQ==,type:str]
+        - realName: ENC[AES256_GCM,data:mPympaP5zpyuBrL0suuOwCM=,iv:4TNcDe/SbGHof9tUaHjmPejCDhv6JNMFGD2uRSdDDBQ=,tag:rA/193LnLTxPdeKBDN52OQ==,type:str]
+          githubName: ENC[AES256_GCM,data:tkjkBCzcIaxC,iv:0y6QEDND9WRXX6+suK0QMoi77Cbp3Ru9V1PpzzCorGY=,tag:JTEjbvPpF3aevMpRJ7ZC6g==,type:str]
+          slackID: ENC[AES256_GCM,data:x71Q8MTlAPWRLFs=,iv:MdDr1MJezwA9xhhdzpwGiXk0IXhQ32vyUrPKhSW1vP8=,tag:3OjjQRDs6Nlv8DA3bGtXXg==,type:str]
+        - realName: ENC[AES256_GCM,data:HIVgWZ1HHDhsHQ==,iv:D5T/k130/2VC1rtnGF+LK7eJSlYyqn86JcRUjfWOGJ8=,tag:HHzRBMAXOclk4gRLontPUQ==,type:str]
+          githubName: ENC[AES256_GCM,data:j5PQQSvnLhphaQ==,iv:plsQxlrd3nEVyiVjBP4I2OVjnnSLHXOWeAvqgnbebqw=,tag:hmntpdi/0dk/1xkPFX1BCQ==,type:str]
+          slackID: ENC[AES256_GCM,data:8DwMXEDTQNEB,iv:yYo0gBi45oO/qV7Lijpr9cOOxDBkmnty8z9t2hHGgdg=,tag:gqgDj7i8VqEFiuRPk5X2Ig==,type:str]
+        - realName: ENC[AES256_GCM,data:Pm/eawxmUQfjkrG5,iv:xDbatDHrFINlr03uuwkOLJgHOoFEX3Badl1WNJpcpGc=,tag:w0eGLCcwNJ/DYlRiMYgfYw==,type:str]
+          githubName: ENC[AES256_GCM,data:dGbAq8bMWSNqfA==,iv:sS7dvh39zbEPf0LESkoBcM6sykutE5bS8rVLn0wC1yA=,tag:sYz98WcfFcqUkEHkpdB9bg==,type:str]
+          slackID: ENC[AES256_GCM,data:XKlYuhJGn0AkrIs=,iv:oqaTXiUBLVu70cs/f6E4jb8IVkw1mFJOx3HUY8WqQqQ=,tag:xP89t+tDUO6BA6AjoAs5Bw==,type:str]
+        - realName: ENC[AES256_GCM,data:C3vaWMpCFMqlU9g=,iv:GHT94QPaacqj7Dqk4ICNVWax47ABKUeommqTdTdQnVo=,tag:Ljf+5aN5iWW1ooFVlmwRCw==,type:str]
+          githubName: ENC[AES256_GCM,data:UTdWsvn8RT635lZX,iv:s3WxZRGkh77fzeknKzwoswFUGQuV8RyTWdLWBMMvBCc=,tag:qGxLGtrl5s10OnPiMcw/dQ==,type:str]
+          slackID: ENC[AES256_GCM,data:X5T7XL/h0Cy1B2Q=,iv:k0fCLJXN7GvueoYNqEjzhSQ9DP7TJHCw56KBtkNohrQ=,tag:YdUjaCU1HhbTMp9TJDvfcQ==,type:str]
+        - realName: ENC[AES256_GCM,data:z/WVlqm9tn4uYJHxkL/8wLc=,iv:Bd5K/tApNNjk3lxPODG7ToCsbm9U8p82phKs7sCSXoc=,tag:Z5K2lSJloOyg/S95jA7FMg==,type:str]
+          githubName: ENC[AES256_GCM,data:aXbX1Ic/whM94gKNmxmfEQ4=,iv:uSpGH1bkn92pU8TSoJdZfdtx/n2vkyI1aDrg9V4bK6o=,tag:RS1IPgf7QJPHp8hDkMrpbw==,type:str]
+          slackID: ENC[AES256_GCM,data:1T1hykjKS38giZo=,iv:EkcaeNly6/sbAjry88n+Wr/uwMm5mFSJPZFHfOHqGrY=,tag:lF0Nyko5vyWI12rpSSo/HA==,type:str]
+        - realName: ENC[AES256_GCM,data:5lCx348JEUvFhSM=,iv:By7J8HgR/aqVzMJB+3k2XXaGP+K/gGj1RPdVbUWf1a8=,tag:dxcsyU9EOIlXd1UOM7uvtA==,type:str]
+          githubName: ENC[AES256_GCM,data:ony8sQjmSND7hQ==,iv:lTLaQVAVwPxpFa/ktNW6j/XVxDU/5btmF822NOcfhTM=,tag:Xv6z0Inj4HizbQoG6PCfLw==,type:str]
+          slackID: ENC[AES256_GCM,data:yVQ+h+Jbp+SMMWM=,iv:tAJUotbs7oylEHVAmaGTgwzJIu+zLI72poDM8hxj6p4=,tag:6cItmH0x573+4ET5QCP8JA==,type:str]
+        - realName: ENC[AES256_GCM,data:zAf43wceyqeDK0teOA==,iv:ijz3FyukLqH4roxJ9ft33o5Q0oVv9CTqWTtSYS9kb3s=,tag:xGpiO+MjllmVu3BV0RJNVQ==,type:str]
+          githubName: ENC[AES256_GCM,data:sqzt1+tJeFNo,iv:ngTj9UJf4+aJJE+CeHOzTpOJ0AcTl0eNozN6kOaPpLQ=,tag:NxBCWG5eZkpejrcc34FPDA==,type:str]
+          slackID: ENC[AES256_GCM,data:t9br7YDPHifKMMA=,iv:ua2ATmXjICbVxVdlp0T219NogOECVzAI9iByVOs9rMg=,tag:pmchL99+5BwF88BbL+NnKw==,type:str]
+        - realName: ENC[AES256_GCM,data:xTlZ8wGx/CEhtWw=,iv:Fn3vETf6upkCrG+Uj+xYTwc3H7jEL4uwrGYeB6/qBww=,tag:2Jxha2zeg0ZEObD86TInpg==,type:str]
+          githubName: ENC[AES256_GCM,data:7tZyCIyH7rrQYC5R/Lyh9sU=,iv:zCvSirz5VwQ/4XDaNoMPebODzVu4ERDEWFC7K/APmF8=,tag:QHRVJ7X1IwOqZRagKIqj8w==,type:str]
+          slackID: ENC[AES256_GCM,data:JHX0tOD7L6irdCk=,iv:3KYhcQKMuPX3wre1YdItZXeuDzHWyS6elEyUvr4K6HQ=,tag:dqhqZzWZyjpniVWIXWEASA==,type:str]
+        - realName: ENC[AES256_GCM,data:R54/HRSy2H4czQVKBe0I,iv:FQyITp7JK5yHcAOpRdOwSRwnTun513BYGKjN8fEOBRM=,tag:Ba+CtPVAyatQwyb1pmeANQ==,type:str]
+          githubName: ENC[AES256_GCM,data:keET5P5SRpAmspM=,iv:u6HqtsvkAd1SGYpol6+uwYsjF/s2aLXfTYEhyAx0OeY=,tag:5E99P2S9EoYztlmVLGyr6A==,type:str]
+          slackID: ENC[AES256_GCM,data:HkZjNr/pFtEwWTA=,iv:2IkYJTR+Deqf/rxJHfh0C9efawKpx/7hMQk/HdESxH4=,tag:acIZjIS/xT/ULMMP45TIwA==,type:str]
+        - realName: ENC[AES256_GCM,data:rZ6fE/NBjxzy742gmCY=,iv:6JYeWecZeEZR7M2DnA6PCottenj0DYwAUtGzmTgfl+U=,tag:azuJGSJoaKGOMjWfZ92Ghg==,type:str]
+          githubName: ENC[AES256_GCM,data:GpiI82TAmkdZRQ2aEP4=,iv:2CVtm6PYV/ufnVvYNtbsz3mBC7pCH9plqMi6pfXg7RE=,tag:QmQm1JEnXA09WepUyXqYRA==,type:str]
+          slackID: ENC[AES256_GCM,data:DiP3J1Md9L+o+lY=,iv:lw7DruM4hrdG1kJOfbsf8ST1TbPaPXNmLafR+ltOu+o=,tag:lrdUjXYn0SGjqtEvqm4zMg==,type:str]
+        - realName: ENC[AES256_GCM,data:arAYOw==,iv:tV5mMV3GtEZZ5v4wiTo2zIaz2CI5vBESWF+34mIrbVs=,tag:aqgVY7nsCHLRQZCgrxA9zA==,type:str]
+          githubName: ENC[AES256_GCM,data:2vkAMOxu,iv:cx1D8FtW9RqluBBYBLZFW/tYE/lS4xUAZE00KrM/mHE=,tag:akD8MQPpLVqdRT5MGKchqQ==,type:str]
+          slackID: ENC[AES256_GCM,data:YEUeIVve3vY9v64=,iv:QH+wNeqYW0hfX6oSfjVKjIrbk/vxDgoiaoLPbUnKHz8=,tag:2g72V96syWXXW7/JsYfJAw==,type:str]
+        - realName: ENC[AES256_GCM,data:qP8Yd8zyTOBbfmt3YXA=,iv:ocSlTFSFC27eOyOjRKIsZwT1sj8nDW394OWLQjvS+YM=,tag:aLHIDDI24Nm2F3FLP9mdiA==,type:str]
+          githubName: ENC[AES256_GCM,data:bnW36bV2hr5KqOY=,iv:Y+eIG/ZvCNxy1+YHVfoe2Nx7efOONEE1rS6mKa03YN0=,tag:sOjMQBXTVRQ4ULV7D/1/+Q==,type:str]
+          slackID: ENC[AES256_GCM,data:6DLljjqN9GYFR7c=,iv:vj1L9wA8Koi3MQRxVC7yHQ9BH0m+VxYI4QYARmYCF4I=,tag:Pxmopw9o50bi0g8oZTXf0g==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -60,23 +69,23 @@ sops:
         - recipient: age1kkmt80g0cq4uud8gtxwa9p9y4l9nwa2mk8rlqp29sgvkku99evesc0gfsl
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3UzM4SjNiMlYxUlpXTUps
-            d2V0ME1Zbm1YSWFvNzUvZkVTZG54QlZON25VCjM3d2wvaEdwSU9nREZ0RHlLK25U
-            UlVrazA1N3NocUhWSTlqTTJFQnQwUXMKLS0tIFJFZVpKSFhOMlN1NVdHVlFVdFdp
-            UGZjNWtoR0FIV2FTRDZtWS9PVE1wOUEKQ194xbkBfW7Qy4KsewzlQtkvd3WcFgrR
-            tDQYabkvnpUXF1uY3wJpj+1NUJhSdzKgsA2Jex7dki092t8Gn06qUg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqREt5eFFBRTJMempwczRJ
+            SU1MdW9ITUpZdGxXQjVHcmZlZTBWeEpQakhjCkZwbWFYUWcxUElpZkNKWGVOVEpw
+            VmtjdFVPemYrM1VPaVBrVUhxazRpZ2sKLS0tIENqRWhYYmVmLzlQTTVSUHJ4NnlS
+            S1pvSmtSZkJRdmhGZFNZZEczeUhtMG8KsvQ11xgKvvu+pi5hSH34GcHHqn316Yrk
+            Y+rAMC/QsUY9FQR7LcE5AiNapPue3ToihCYN8nmGMcGlZ84kdQLPGA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1hsll27prywydttq7dtnqtdnu2jpr8zhaulx00l7n4pqmxkhr55vspqmj6l
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlaldRWWpqQzFNN1IyQ1BJ
-            bXM0TUw4NU1FdjlkczF3dDQ4TXJSeHFnNlZvCldwNWtHSmlUTS91MWpTa2JCcnBa
-            WU1xZTBiS1FMSU1wT3dZcFRaNE5QY2sKLS0tIFZRODdDYUJVY2NlNEErUWJYNTlS
-            em5CQkFXcTFzNktpWE5kMk9UK3pnL00K3yFaArhA3HvzTVnvtar3zYkvvbnX4TYd
-            ggyFQiHqsWmPGPb8vvDDN676z74TWx/iIXNdaYTA0DQoMv3Tzl+1SA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvUHNSYU9FMkFJQzBlQzZh
+            ajI4TlVWL2YwNUg5VS9PUzVwZy9ndHU1bEJRCk5Ja1V2M3p1RUpoWGtRNGM5Tkpy
+            ZDc2eklVRFVGUXM0ekNIY3Jxei9UVGcKLS0tIE0vZEMzVVBFZlRtUWNLWkxKN0d5
+            Wmlla0EraUxIWWczenhsY3NMNjJqSWsK0BkA6nc25pQxkNU0pxYBZJ0f3Kg5AvV5
+            ptAACwLxuKbiCldMrgdZqoPoif7X89iwghMDy16l8vyKS27q3DmFdA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-01-28T11:57:01Z"
-    mac: ENC[AES256_GCM,data:UsGBbMCvD7VidWSvAXEFQ1DkzeIEBz0A3aL96vCPktDXswPciMm6fvWxlhwR6jnVIdr0VyYsUAkwiE5WBapnpBf5zqS7p9wp2+K4+njk7aDQmIlbGCUQkP4x9IApg11W3kgEgb7xLwcfzlK+GMkG5+E+AwmFiAwQtqF0EveJaoU=,iv:JhNwDqvrxd1QUvHP0Rwm28GYmWd+0X4eB2ON2yloMnk=,tag:GFDPTWJWBcVvqOatw42MXg==,type:str]
+    lastmodified: "2025-01-20T10:04:40Z"
+    mac: ENC[AES256_GCM,data:q/sSf70JjT9Q9gA5YiQUwulXGy8mpz2Ewf/YD2WuwYx3OhXYGHtTq1ZzUmCoCDmDmm6SNiOBb2gc6Lwh/rlcB4hqK7iRLs2db0OnttxEoxhfsMhy+77J594Uzp/c7b5ybM0q8FfXDdWUr3g83xBnGhtJ2JPGIhESnLqBaWbWlDY=,iv:5sIOEKPgWNIdavDT3CQXvo/SZlM9SDyBtNgfRfJmczo=,tag:doeASmEz9TLs1ZI9xqBFsw==,type:str]
     pgp: []
     unencrypted_regex: ^(apiVersion|metadata|kind|type)$
     version: 3.9.1


### PR DESCRIPTION
### Description:

Adding more cloud members to the values so their names are updated in the messages.

---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
