### PR TITLE
BUG: fix app-cred for chatops cluster

### DIFF
--- a/secrets/dev/cloud-chatops/infra/app-creds.yaml
+++ b/secrets/dev/cloud-chatops/infra/app-creds.yaml
@@ -6,17 +6,18 @@
 #ENC[AES256_GCM,data:cqBaI9xRoTrsBnfIXzemsfbAoDwCHae2pLhplZhxq/URb4D9UYx+2rN5fzm+ig+eMcoaj4mpCss4w25u9JJLKBfoEJVx7L6F592k,iv:I7HqiKNw9G1Ao0wyyvAjbyzBYYJBEbZT3eZ9LEyO/JE=,tag:mo3bIhR0BCNzuda7aHpyvg==,type:comment]
 #ENC[AES256_GCM,data:pSl4auDbDcB2xiBdEyplPglluhdbpMVdXZVU2DqWuBGJqQ6Q5XZNRmhuVoBylCdk/dc73ULEkjHORASzvhqu4DBOOMWg,iv:f7BUs0caIlDHDBxl+RGwnvTTC+zt0u5OaDiSS5AhCYA=,tag:7usLsfZYA32W62Md/3jQyw==,type:comment]
 #ENC[AES256_GCM,data:Xtl35HuKr1yvHfuFBrODGQ9LgUl7RhF+xKTAfGwRF6fZEpae9MkXw+LsYg==,iv:3stho7S2/xrXdlJJK3nT5w27NP+tbE1cmKaTg5cRBos=,tag:e4bkE5joU+ZNv+gWZnVwOQ==,type:comment]
-clouds:
-    openstack:
-        auth:
-            auth_url: ENC[AES256_GCM,data:ZiOYN6XuZBI03KD8/soXsEwuA7VbU7nOiSZjxnRqPMkIM1aYMg==,iv:Qn9Zf4oBavPEfoMCUgaxV/yBCipeF5ro5CpPK2Cefi0=,tag:tzIkL7agJ3Wd/MykECuMRQ==,type:str]
-            application_credential_id: ENC[AES256_GCM,data:+ljfpb4yrCrsbIme0O8Jn1G+nax6RPaGB92KKUhLG6w=,iv:AjW2Lycb9+Q3DC2d3u2g0zTMtU2en1KN5WJfPjmILVs=,tag:DzR6LdDxFlZRFat6bF97zw==,type:str]
-            application_credential_secret: ENC[AES256_GCM,data:mQHyXFwFEhv2TanQccxFLDM5wAGbKINblFQLzMdw0BXdCcf2NfnYXiAKbzZlKlMpRJa+c0SGWNBNOJJ3Qomu0HQefaj1Ma9HCTItQcQynSDSZsDWuzM=,iv:lNFo8BFli68g1rEIi0EHIsXkR7kTDHEyxFqdOIhBucc=,tag:o7FpR5qUsJ0cl7T6hPMj7w==,type:str]
-            project_id: ENC[AES256_GCM,data:JGgLAuxQs7kUSlO4ulm3OjXzf/YiASOCbGIAGJKA8Pw=,iv:AlY9aWGKPQOJ22U5URJxAXCMzXrf9kb+gImuhrMiiNA=,tag:qdUZwB9Kve5DfUcaNw1c9A==,type:str]
-        region_name: ENC[AES256_GCM,data:ExY49oVX5tY6,iv:O6hGdERDl7iPldkwICB0tmkQWCz7lb47jhAcAqh6FJA=,tag:5izWyoTNzTXaCkFzug3FIg==,type:str]
-        interface: ENC[AES256_GCM,data:BV0AXjMP,iv:G8RuGm4C2ZcW4zjcZDtArx17SaNgV69faa1onzZvBlw=,tag:NdzD/LHNJQGdPpzoxz+Dkw==,type:str]
-        identity_api_version: ENC[AES256_GCM,data:Dg==,iv:wXBNAs0YYj5j77uKySbbdunNGpG0Xsvsrb9VHfcNHwI=,tag:d30rdzMMCcJYOP4wlVaGEA==,type:int]
-        auth_type: ENC[AES256_GCM,data:zcq/cXMhl3kL1HGe0+80DlVsUyKbqi8=,iv:a42kIn2Slsk0aMY+rKef9eNRlxnsDRsRxptts4osvyg=,tag:IHYFXXKXZx9hlwELJWlf9Q==,type:str]
+openstack-cluster:
+    clouds:
+        openstack:
+            auth:
+                auth_url: ENC[AES256_GCM,data:QL8dcy7pxJ8x0yPInKEA/unnVWavJDYhp9hceaYVyVeCcmIhOA==,iv:SFJ0roo3CBlMn5vbuI0sdXnGkd7/fdCXC0JgCEBD+E4=,tag:ls+Q2ldMcbw0aYWMcS2oWA==,type:str]
+                application_credential_id: ENC[AES256_GCM,data:5z+cb1zuKUwS5jmAUcvfV4d0shE6sNZwRlGYDWEz5V0=,iv:na5VdA0MhJX5C1F3dKAmZmwI9dlW+urYxwmBEP0euBY=,tag:wKhtCJq1u7JNrt58m8o5Ag==,type:str]
+                application_credential_secret: ENC[AES256_GCM,data:vaIiB96T1jmHF0asClXfG3O5LSpp17YjjifvLg6n3daysxRNMWt/e5QiYguvVoyUJkvM3j/X4GZuYI4rWuXbUa+xNWJvRhv0RtZUOFeGGabPd2az7MY=,iv:FtSDgYMzB05U44N2N6ic/ZzDXSkrdoxgiCD/CzAJSCs=,tag:I+iRxJEU2tk5uHeTQglgBA==,type:str]
+                project_id: ENC[AES256_GCM,data:S47J6eUq8ZSz92xU11l2mS/u/gLvm5q6KkkdCXgcQzY=,iv:JlUwas9ac6Jz2DwyTkRa8PFQVCBg7TrHMh/0SW2AWH4=,tag:xs1NseYZViH1D+BJFDei0w==,type:str]
+            region_name: ENC[AES256_GCM,data:EhgfEgkbytP+,iv:Si9o7zfozTf/z1Jo+TUK4QI0pHvQAXyMpxhLnKDl4jY=,tag:H2o8Z80/o6saUndyL/5pUA==,type:str]
+            interface: ENC[AES256_GCM,data:F75sIsV+,iv:QiGV2nw7NcYcCxT1Pdc8rRjPie75YKFyiz/bzGDD9T4=,tag:Q6yvhqFvuNclGD3dfNSsMQ==,type:str]
+            identity_api_version: ENC[AES256_GCM,data:MQ==,iv:g6JG9JP09jq5TUFG0tOKiB+kf3agE5vPk45AZV6oZ8o=,tag:Nk0zulFT+sa+FKnYdwf2pg==,type:int]
+            auth_type: ENC[AES256_GCM,data:0UiNmx2IxG/8meSPjcVd7S4fMUs9bp4=,iv:CjLyFxQo9dYxcDu143oTWvPDCpK+ILae01qRwuVv3bk=,tag:FmaW+y+FCA22p8tu9hl1aA==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -95,8 +96,8 @@ sops:
             dVBVVzFCTFRuMUxCclBFNVQ1WVJNVG8KBEp3+wI94wxMXRB3cc7EaKZBLjEhyqOc
             g5dxmTzrvvyog52XZfc7wzTSMDt6jGw1AQzuMCijZ0qLVUIFyYkbog==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-01-21T13:02:09Z"
-    mac: ENC[AES256_GCM,data:pHPnanhQgfdLCbUSW3aXJniCC/zY5g7URkqeFUzN95uQ+69IvQSaguGl65PGQZKesM8lYvrF1BpKQRKxl+yzeLr1g2AvifRg2rJDgV9wrb6ZyG1U0nyfa64RXBTuRBDUpS0XRy63rmJdbNEEztAAuiue2V9YXn/yNhxIP0EswWA=,iv:etBdqWf5jgz8nWHtn9L0j+wU/wPmvqHhnh8Bk1xE+3I=,tag:nAd07mEDrHnv65mDTKuuJw==,type:str]
+    lastmodified: "2025-01-27T10:09:24Z"
+    mac: ENC[AES256_GCM,data:6Kbo9nxNGlFKUMASqTXHII896EbBb6WVl5W/IZC80sn9dtUn5brZHZxdOhtXvHEMrT1x20tu27iPWGbxIawQHAxggBcgvEkN32q6+Zk7ZW0XlwPwyHwcEfuttUW+RW3osjI6RsCZI7SKe20FhgXVZ6K3F3cnu1qBnnPocpsuIZM=,iv:C99y9yQN9DZntW55Aj1Q40MjPycweHgcyISVERePnPc=,tag:GwrbrmmmMWP5JAxeLTksGQ==,type:str]
     pgp: []
     unencrypted_regex: ^(apiVersion|metadata|kind|type)$
     version: 3.9.1


### PR DESCRIPTION
encase secret values in `openstack-cluster` as the config belongs to the dependency chart
