### PR TITLE
[ENH] vmbackup config

### DIFF
--- a/charts/dev/manila-csi/templates/manila-secret.yaml
+++ b/charts/dev/manila-csi/templates/manila-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: csi-manila-secret
+  namespace: kube-system
+type: Opaque
+stringData:
+    os-authURL: {{.Values.manilaCreds.OSAuthURL}}
+    os-region: {{.Values.manilaCreds.OSRegion}}
+    os-applicationCredentialID: {{.Values.manilaCreds.OSApplicationCredentialID}}
+    os-applicationCredentialSecret: {{.Values.manilaCreds.OSApplicationCredentialSecret}}

--- a/charts/dev/victoria-metrics/values.yaml
+++ b/charts/dev/victoria-metrics/values.yaml
@@ -46,3 +46,10 @@ victoria-metrics-cluster:
 
       size: 10Gi
       storageClass: "csi-manila-cephfs"
+
+    initContainers:
+      - name: vmbackup
+        image: victoriametrics/vmbackup
+        imagePullPolicy: IfNotPresent
+        args:
+        - -snapshot.createURL=http://localhost:8482/snapshot/create

--- a/charts/dev/victoria-metrics/values.yaml
+++ b/charts/dev/victoria-metrics/values.yaml
@@ -47,10 +47,19 @@ victoria-metrics-cluster:
 
       size: 10Gi
       storageClass: "csi-manila-cephfs"
-
-    initContainers:
+    
+    extraContainers:
       - name: vmbackup
-        image: victoriametrics/vmbackup
-        imagePullPolicy: IfNotPresent
-        args:
-        - -snapshot.createURL=http://vmstorage:8482/snapshot/create
+        image: victoriametrics/vmbackup:v1.96.0
+        command:
+          - "/bin/sh"
+          - "-c"
+          - |
+            echo "vmbackup sidecar running. Use this container for backups."; \
+            while true; do sleep 3600; done
+        volumeMounts:
+          - name: vmstorage-volume # Matches the StatefulSet volume claim name
+            mountPath: /storage
+  
+    podSpec:
+      volumes: [] 

--- a/charts/dev/victoria-metrics/values.yaml
+++ b/charts/dev/victoria-metrics/values.yaml
@@ -39,6 +39,7 @@ victoria-metrics-cluster:
   vmstorage:
     retentionPeriod: 1 # month
     replicaCount: 5
+    fullnameOveride: "vmstorage"
 
     persistentVolume:
       enabled: true
@@ -52,4 +53,4 @@ victoria-metrics-cluster:
         image: victoriametrics/vmbackup
         imagePullPolicy: IfNotPresent
         args:
-        - -snapshot.createURL=http://localhost:8482/snapshot/create
+        - -snapshot.createURL=http://vmstorage:8482/snapshot/create

--- a/clusters/dev/vicmet/apps.yaml
+++ b/clusters/dev/vicmet/apps.yaml
@@ -29,7 +29,6 @@ metadata:
   namespace: argocd
 spec:
   goTemplate: true
-  goTemplateOptions: ["missingkey=invalid"]
   generators:
     - list:
         elements:
@@ -57,6 +56,7 @@ spec:
             chartName: manila-csi
             namespace: manila-csi
             valuesFile: ../../../clusters/dev/vicmet/argocd-setup-values.yaml
+            secretsFile: ../../../secrets/dev/vicmet/apps/manila-secret.yaml
 
           - name: victoria-metrics
             chartName: victoria-metrics
@@ -82,7 +82,6 @@ spec:
           valueFiles:
             - '{{.valuesFile | default "../../../secrets/dummy-secret.yaml"}}'
             - secrets://{{ .secretsFile | default "../../../secrets/dummy-secret.yaml"}}
-
       destination:
         server: https://kubernetes.default.svc
         namespace: "{{.namespace}}"

--- a/clusters/dev/vicmet/apps.yaml
+++ b/clusters/dev/vicmet/apps.yaml
@@ -10,7 +10,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/stfc/cloud-deployed-apps.git
-    targetRevision: main
+    targetRevision: victoria-staging
     path: clusters/dev/vicmet
   syncPolicy:
     automated:
@@ -76,7 +76,7 @@ spec:
       project: default
       source:
         repoURL: "https://github.com/stfc/cloud-deployed-apps.git"
-        targetRevision: main
+        targetRevision: victoria-staging
         path: "charts/dev/{{.chartName}}"
         helm:
           valueFiles:

--- a/clusters/dev/vicmet/apps.yaml
+++ b/clusters/dev/vicmet/apps.yaml
@@ -10,7 +10,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/stfc/cloud-deployed-apps.git
-    targetRevision: victoria-staging
+    targetRevision: main
     path: clusters/dev/vicmet
   syncPolicy:
     automated:
@@ -76,7 +76,7 @@ spec:
       project: default
       source:
         repoURL: "https://github.com/stfc/cloud-deployed-apps.git"
-        targetRevision: victoria-staging
+        targetRevision: main
         path: "charts/dev/{{.chartName}}"
         helm:
           valueFiles:

--- a/secrets/dev/vicmet/apps/.sops.yaml
+++ b/secrets/dev/vicmet/apps/.sops.yaml
@@ -1,0 +1,22 @@
+creation_rules:
+  - unencrypted_regex: "^(apiVersion|metadata|kind|type)$"
+    # All developers can access / edit secrets on dev
+    key_groups:
+      - age:
+          # Dev Vicmet Cluster - ArgoCD Access Key (Temporary)
+          - age1d3a9z6xz4vk974vk7hgqzl6pgehzguldgm0xjntuyj9666thu4ps0yxh80
+          
+          # PERSONAL ACCESS - FOR DEV ONLY
+          
+          # David Fairbrother Desktop
+          - age1acqcungzwkt807d3jt94ngtdt0vhk9kec4ps4a22cpaah57jw4xsl7q4xc
+          # David Fairbrother Laptop
+          - age1h3dmygqf4v6jg3nxk5sr9jkp27w3q83sqnqxdd5n92xf3w6fs5kshakrxn
+          # Anish Mudaraddi
+          - age12khufkd7z25eqgpjjyy0zcrq6kpjxzekmff5zhq7q54tajm4e58qul35x0
+          # Ramzi Jalili
+          - age16fufeddr0arrns268526gxethxgkh3g0euf8cn37kuwfmq3h23psutz4q8
+          # Ryan Whiting
+          - age1a8e4gxw67kp27s3hssfxyem3e8jwaha3huz0sttfngeu60pk5pxqkfpg3d
+          # Kalibh Halford
+          - age1drky6caal0j2x58yzpw9tyflcpdpmcjqy8nss7zfvspszg0xfpdsyzu8s4

--- a/secrets/dev/vicmet/apps/manila-secret.yaml
+++ b/secrets/dev/vicmet/apps/manila-secret.yaml
@@ -1,0 +1,79 @@
+manilaCreds:
+    OSAuthURL: ENC[AES256_GCM,data:M6TXGw4QOmWmDoWCAt1tva1CxauzoiwXkKS1Q3qjoRhUO+xA,iv:U3nYPlEKp/nEH6rEA8couZETO+thGdpWuInPZAmAtB0=,tag:fYZ7/KGDXyryBwKJeUQGyA==,type:str]
+    OSRegion: ENC[AES256_GCM,data:dwiJhYw5PZiz,iv:oxIhpWBNQ6vxMHr9er9qTx7UfJ7svsrgwFVSqXD1vGw=,tag:V9K3qpr6e+V4ya1KSdXQ5w==,type:str]
+    OSApplicationCredentialID: ENC[AES256_GCM,data:bbstYoa/2gXi2r6w/R2/FR0B8hFU7r0QV5Ae8jQa8g8=,iv:oWUVhhqRXnY1SDTISY7UgC8YaUJe3LPjoDHy6aiYcMk=,tag:GFGJEEx+msSfjEh+AtCgHw==,type:str]
+    OSApplicationCredentialSecret: ENC[AES256_GCM,data:LeShuOPl7XW9KbFt7H24vixZ/0e35aFCiz3euM6EKj3EDvQa/UfeQ0xRP9Dad94NH5tyH34WIC3lMQpTOxj1LpP2FgQTurVNI1iLLMsQ5BI+kP2bogI=,iv:CXVVbV70u1ZzOFm+gM1e6I5WzdK7NZPvbLT/ycbxUI8=,tag:9D75ylJaoIuA2K+pdv9nBw==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1d3a9z6xz4vk974vk7hgqzl6pgehzguldgm0xjntuyj9666thu4ps0yxh80
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXOU5pS0xWZ1BMa3FpbUZ3
+            MmNNN3lBZGdUMVpzbnlhWWVzNjB4QUR2SFVRCnV0RXg0blR2VGpJV0JVUGRjdUJt
+            QXhrNitxaVp6Sk9aMzdobm8vTEh3THcKLS0tIGJ1WGlJbzIwb0dQa3gyQUV5K3pI
+            dVYyMXhqRUszcTYwdWFoTllLaHc1SDAKdEyA4IuTbLUJypdwjjcstnJGPHXSTXpl
+            f+JJoKW2enHeqvWOh4b+DVRXYpl4P7+k4bhIngp4wnE4lmxqwXfCuA==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1acqcungzwkt807d3jt94ngtdt0vhk9kec4ps4a22cpaah57jw4xsl7q4xc
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaT1MySXBiRDBlUFJZNFBU
+            MU95OWVFcXk1RnFTWGl2Sk1VeTV1M2l2NTNFCnpoT0xHVUphNWp0UE05d2FzTW85
+            anhuZWFVaUlSSjZSUGJqOWhGWS90cFkKLS0tIEduQ1JwUGhIY3ZHTUt0SmJUOHY3
+            WkFjMVFFZXFLN0ZHNzBRZ0dHRzhHMk0KfvZQco/YDYZ81HWx8BvlGandGe6JtlM/
+            r6xexs2s2PmKdtRHHCCIhKMT8aL02DoPoHmRwFWx8R13MRcT81VAIA==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1h3dmygqf4v6jg3nxk5sr9jkp27w3q83sqnqxdd5n92xf3w6fs5kshakrxn
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXZkdyclFKakNLcGVFcXVJ
+            ZmRMWklCUEh3cmNYcExSZVdTVVFJM1RVVm5VCkFocVFta1BTTVgwS3VOdzhlODdW
+            T0d1MXBiYWUzQ2x3ZzRyQ0tUa1IzRmMKLS0tIGxuZlJhVVhxQWFyWi9sUDZGY0Fq
+            VzFPSVVEcmZuazZjREl0SHZHZEF6V0kKh9IsWbYJmsudf35MD+jV9lvejuUCgrdD
+            MqymNe/fmvTl5CtWYQgoOWCc1FKQ++5Wm8vD91ck9SeZUfvil+gyyQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age12khufkd7z25eqgpjjyy0zcrq6kpjxzekmff5zhq7q54tajm4e58qul35x0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzaEN0NUhVMFlzMWlwdy9G
+            VEhFWHNSWEZlVkNRNkZqYkxLcVlhZjFBbmpNClpaNmNFL01RMi9qS25RRzlXOFNV
+            ZGpTZHRGdldtM0NVNUdjazI1RGZMNWsKLS0tIEI4WFZ6ODF5cnJMZk56OE85aEdO
+            VEQ5ZjU0aDQ1UmNHdUZqMVlEN013dUkKwh5jUsp+uAAG2wwvwIe5KWhl8WIXq3yC
+            9O9PJ1pPdYspH8Fsx37Y4vb/yKCXaROo5pb5u7Dxaq5TuzwlFgklew==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age16fufeddr0arrns268526gxethxgkh3g0euf8cn37kuwfmq3h23psutz4q8
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLZUYrdmFiWkpobFZEYnBB
+            WlJBTUJyTVIzUTJhOWhOS2hreHh5c3pkSXhRCkRCSnpFbmdmWUsxZENQdW5qS0JW
+            cmdqazBTS1F6L2Q4SUJ3ZmdTdGI0T0UKLS0tIHRTbURNTVlIUkltUExFK0lGZXJi
+            dUpjcVR6ZzVzU1VMeU42SWRkejhFaE0KR+7K6KRpT/ITwjYfONejxM+HDtla4EdN
+            vjYWsn0Ew3qc8lvfCYlUivi3sjft2J+HT6cmt3Zj95r/duFfmKXNvA==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1a8e4gxw67kp27s3hssfxyem3e8jwaha3huz0sttfngeu60pk5pxqkfpg3d
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvc3huVFpRUnlYcFp3R3dF
+            b29pOHdIMlUvR2ZWKytXMlpRVUNZK1o4MFRBCjhVMlJyeGNiMlJBeUNyWUJuS1FD
+            ck1wc2p0REY4Mkg2VWxBMVJKcVJwd1UKLS0tIGM0VnBVRHJvT1E5ekwvc0VXcm5Y
+            dzFiUUtUc3h1dHpHMHBsOHBBV1dpcmcKWtDz61Z6Vf1n2Cj0Aeqtr3gOQ7DcWG/8
+            gQaJRN+/cHLvyrPRiVKYa+F1J1TN9r0STrR1d3wyW5soXpsTvczbNA==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1drky6caal0j2x58yzpw9tyflcpdpmcjqy8nss7zfvspszg0xfpdsyzu8s4
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4c1ZudHBsNXUwN1dLNllG
+            Qk5UTzRvZ3dwZVhoZEFJcG9IWFFWblhtN0hjCmwvaXNrZm1vZ1lUMlZmaWtteTU4
+            Rit3Qk1WUGhLa0ZIVUxvdmhlbXRxT2cKLS0tIDAyWFZ5SGxpVHA1QllZVmZERmp5
+            bytadnhnTUsxTWFXZy9ablhjMUFLek0Kb3rsDVcL2AiYJxXBbtpWvOzru68TeD3h
+            hj9m1v3QZ3V3wEF+YH7w5JTuuvg1awcfpySp+R2Bf4au1RjkYLe1rg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2024-12-10T14:44:47Z"
+    mac: ENC[AES256_GCM,data:YfaQinVFTG7BTdnpDHNJmbhkzYrR54OEN2mSMBHj7JScYJrsyLCnO5t0NJhDhZ38AKtvEOdB2IdWbgXAAADlorMGzQD8U44tcgqLePeI76W751h3Pww5KNp3caZGi2Zbp+NSWiKOfkX+EkqJ6mGU+WWRcVVaZoru3qTWLngzGI0=,iv:6jEeyY4BdZGOyciUQlHxmSSxohCvFnS7YsMr8cjrlLI=,tag:Vkz8PmJRhmub41L1viyVNA==,type:str]
+    pgp: []
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.8.1


### PR DESCRIPTION
### Description:

Added config for the vmbackup sidecontainer to run alongside the vmstorage pod
vmbackup will be interactable from kubectl 

---

### Submitter:

Have you:

* [ ] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
