### PR TITLE
bump dev charts to staging

### DIFF
--- a/charts/dev/cert-manager/Chart.yaml
+++ b/charts/dev/cert-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cert-manager
-version: 1.0.0
+version: 1.1.0
 dependencies:
 # https://github.com/cert-manager/cert-manager/releases
   - name: cert-manager

--- a/charts/dev/opensearch/secret-templates/opensearch.yaml
+++ b/charts/dev/opensearch/secret-templates/opensearch.yaml
@@ -10,7 +10,7 @@ admin:
   password: admin
   # bcrypt hash of password - default is 12 rounds unless changed in settings
   # plugins.security.password.hashing.bcrypt.rounds
-  hash: $2y$12$nfO6TYibMCV6E2wPuYoiq.psAV2dl2wmAL5ZEU.VOkaB4z4GCLVVK
+  hash: $2y$12$nfO6TYibMCV6E2wPuYoiq.psAV2dl2wmAL5ZEU.VOkaB4z4GCLVVK # admin
 
 # IRIS IAM Client credentials
 openid:

--- a/charts/staging/cert-manager/Chart.yaml
+++ b/charts/staging/cert-manager/Chart.yaml
@@ -1,3 +1,8 @@
 apiVersion: v2
 name: cert-manager
 version: 1.0.0
+dependencies:
+# https://github.com/cert-manager/cert-manager/releases
+  - name: cert-manager
+    version: 1.15.3
+    repository: https://charts.jetstack.io

--- a/charts/staging/cert-manager/Chart.yaml
+++ b/charts/staging/cert-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cert-manager
-version: 1.0.0
+version: 1.1.0
 dependencies:
 # https://github.com/cert-manager/cert-manager/releases
   - name: cert-manager

--- a/charts/staging/cert-manager/requirements.yaml
+++ b/charts/staging/cert-manager/requirements.yaml
@@ -1,5 +1,0 @@
-dependencies:
-# https://github.com/cert-manager/cert-manager/releases
-  - name: cert-manager
-    version: 1.14.5
-    repository: https://charts.jetstack.io

--- a/charts/staging/cert-manager/values.yaml
+++ b/charts/staging/cert-manager/values.yaml
@@ -9,6 +9,4 @@ cert-manager:
   le-prod:
     enabled: false
 
-  crds:
-    enabled: true
-    keep: true
+  installCRDs: true

--- a/charts/staging/chatops/values.yaml
+++ b/charts/staging/chatops/values.yaml
@@ -1,4 +1,4 @@
-env: staging
+env: dev
 app: cloud-chatops
 replicaCount: 1
 image:

--- a/charts/staging/cluster-api-addon-provider/Chart.yaml
+++ b/charts/staging/cluster-api-addon-provider/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cluster-api-addon-provider
-version: 1.0.0
+version: 1.2.0 
 dependencies:
   - repository: https://azimuth-cloud.github.io/cluster-api-addon-provider
     name: cluster-api-addon-provider
-    version: 0.7.1
+    version: 0.7.2

--- a/charts/staging/cluster-api-addon-provider/requirements.yaml
+++ b/charts/staging/cluster-api-addon-provider/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-  - repository: https://azimuth-cloud.github.io/cluster-api-addon-provider
-    name: cluster-api-addon-provider
-    version: 0.6.1

--- a/charts/staging/opensearch/Chart.yaml
+++ b/charts/staging/opensearch/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: opensearch
+version: 1.0.0
+dependencies:
+  - repository: https://opensearch-project.github.io/opensearch-k8s-operator/
+    name: opensearch-operator
+    version: 2.6.1

--- a/charts/staging/opensearch/secret-templates/opensearch.yaml
+++ b/charts/staging/opensearch/secret-templates/opensearch.yaml
@@ -1,0 +1,18 @@
+# THIS IS A TEMPLATE FOR SOPS SECRETS 
+# copy this file into relevant cluster folder in secrets directory
+# then run sops ecrypt <filename>.yaml - DON'T CHANGE THE FILENAME  
+# application: opensearch
+
+admin:
+  # Provide username and password for the initial admin user - used to configure and manage the cluster
+  # You must provide the password in plaintext and as a bycrpt hash 
+  username: admin
+  password: admin
+  # bcrypt hash of password - default is 12 rounds unless changed in settings
+  # plugins.security.password.hashing.bcrypt.rounds
+  hash: $2y$12$nfO6TYibMCV6E2wPuYoiq.psAV2dl2wmAL5ZEU.VOkaB4z4GCLVVK
+
+# IRIS IAM Client credentials
+openid:
+  clientID: iris-iam-id
+  clientSecret: iris-iam-secret

--- a/charts/staging/opensearch/secret-templates/opensearch.yaml
+++ b/charts/staging/opensearch/secret-templates/opensearch.yaml
@@ -10,7 +10,7 @@ admin:
   password: admin
   # bcrypt hash of password - default is 12 rounds unless changed in settings
   # plugins.security.password.hashing.bcrypt.rounds
-  hash: $2y$12$nfO6TYibMCV6E2wPuYoiq.psAV2dl2wmAL5ZEU.VOkaB4z4GCLVVK
+  hash: $2y$12$nfO6TYibMCV6E2wPuYoiq.psAV2dl2wmAL5ZEU.VOkaB4z4GCLVVK # admin
 
 # IRIS IAM Client credentials
 openid:

--- a/charts/staging/opensearch/templates/admin-secret.yaml
+++ b/charts/staging/opensearch/templates/admin-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.clusterName }}-admin-credentials-secret
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+stringData:
+    username: {{ .Values.admin.username }}
+    password: {{ .Values.admin.password }}

--- a/charts/staging/opensearch/templates/longhorn-storageclass.yaml
+++ b/charts/staging/opensearch/templates/longhorn-storageclass.yaml
@@ -1,0 +1,10 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-opensearch
+provisioner: driver.longhorn.io
+parameters:
+  numberOfReplicas: "1"
+  migratable: "true"
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/charts/staging/opensearch/templates/opensearch-cluster.yaml
+++ b/charts/staging/opensearch/templates/opensearch-cluster.yaml
@@ -1,0 +1,72 @@
+apiVersion: opensearch.opster.io/v1
+kind: OpenSearchCluster
+metadata:
+  name: {{ .Values.clusterName }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+spec:
+  security:
+    config:
+      adminCredentialsSecret:
+        name: {{ .Values.clusterName }}-admin-credentials-secret
+      securityConfigSecret:
+        name: {{ .Values.clusterName }}-securityconfig-secret
+    tls:
+      transport:
+        generate: true
+        perNode: true
+      http:
+        generate: true
+  general:
+    serviceName: {{ .Values.clusterName }}
+    setVMMaxMapCount: true
+    version: {{ .Values.version }}
+    httpPort: {{ .Values.httpPort | default 9200 }}
+    monitoring: {{ toYaml .Values.monitoring | nindent 6 }}
+    pluginsList: {{ toYaml .Values.pluginsList | nindent 6 }}
+  confMgmt:
+    smartScaler: {{ .Values.useSmartScaler | default false }}    
+  dashboards:
+    tls:
+      enable: true
+      generate: true
+    enable: {{ .Values.dashboards.enabled | default true }}
+    version: {{ .Values.version }}
+    replicas: {{ .Values.dashboards.replicas | default 1 }}
+    opensearchCredentialsSecret:
+      name: {{ .Values.clusterName }}-admin-credentials-secret
+    additionalConfig:
+      opensearch_security.multitenancy.enabled: "true"
+      opensearch_security.cookie.secure: "true"
+      {{ if .Values.openid.enabled }}
+      opensearch_security.auth.type: | 
+        ["basicauth", "openid"]
+      opensearch_security.auth.multiple_auth_enabled: "true"
+      opensearch_security.openid.connect_url: "https://iris-iam.stfc.ac.uk/.well-known/openid-configuration"
+      opensearch_security.openid.client_id: {{.Values.openid.clientID}}
+      opensearch_security.openid.client_secret: {{.Values.openid.clientSecret}}
+      opensearch_security.openid.scope: "openid profile email preferred_username groups"
+      opensearch_security.openid.base_redirect_url: https://{{ index .Values.dashboards.ingress.hosts 0 "host"}}
+      {{ end }}
+
+  nodePools:
+    {{- range .Values.nodePools }}
+    - component: {{ .component }}
+      replicas: {{ .replicas }}
+      diskSize: {{ .diskSize }}
+      persistence:
+        pvc:
+          accessModes:
+            - {{ .accessModes | default "ReadWriteOnce" }}
+          storageClass: {{ .storageClass | default "longhorn-opensearch" }}
+      nodeSelector: 
+        {{- toYaml .nodeSelector | nindent 10 }}
+      roles:
+      {{- range .roles }}
+        - {{ . }}
+      {{- end }}
+      pdb:
+        enable: {{ .pdb.enable | default false }}
+        maxUnavailable: {{ .pdb.maxUnavailable | default 1 }}
+    {{- end }}

--- a/charts/staging/opensearch/templates/opensearch-dashboards-ingress.yaml
+++ b/charts/staging/opensearch/templates/opensearch-dashboards-ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.dashboards.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.clusterName }}-dashboards-ingress
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.dashboards.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.dashboards.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.dashboards.ingress.ingressClassName }}
+  {{- end }}
+  tls:
+    {{- range .Values.dashboards.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+      - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  rules:
+  {{- range .Values.dashboards.ingress.hosts }}
+  - host: {{ .host | quote }}
+    http:
+      paths:
+      {{- range .paths }}
+      - path: {{ .path }}
+        pathType: {{ .pathType }}
+        backend:
+          service:
+            name: {{$.Values.clusterName}}-dashboards
+            port:
+              number: 5601
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/staging/opensearch/templates/opensearch-nodes-ingress.yaml
+++ b/charts/staging/opensearch/templates/opensearch-nodes-ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.clusterName }}-opensearch-ingress
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+      - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+  - host: {{ .host | quote }}
+    http:
+      paths:
+      {{- range .paths }}
+      - path: {{ .path }}
+        pathType: {{ .pathType }}
+        backend:
+          service:
+            name: {{$.Values.clusterName}}
+            port:
+              number: 9200
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/staging/opensearch/templates/security-config-secret.yaml
+++ b/charts/staging/opensearch/templates/security-config-secret.yaml
@@ -1,0 +1,250 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{.Values.clusterName}}-securityconfig-secret
+  namespace: {{.Release.namespace}}
+type: Opaque
+stringData:
+      action_groups.yml: |-
+         _meta:
+           type: "actiongroups"
+           config_version: 2
+        {{- if .Values.actionGroups }}
+        {{ .Values.actionGroups | toYaml | nindent 8 }}
+        {{- end }}
+      internal_users.yml: |
+        _meta:
+          type: "internalusers"
+          config_version: 2
+        admin:
+          hash: {{ .Values.admin.hash }}
+          reserved: true
+          backend_roles:
+          - "admin"
+          description: "Demo admin user"
+        {{- if .Values.users }}
+        {{ .Values.users | toYaml | nindent 8 }}
+        {{- end }}
+      tenants.yml: |-
+        _meta:
+          type: "tenants"
+          config_version: 2
+        {{- if .Values.tenants }}
+        {{ .Values.tenants | toYaml | nindent 8 }}
+        {{- end }}
+      roles_mapping.yml: |-
+        _meta:
+          type: "rolesmapping"
+          config_version: 2
+        {{- if .Values.rolesMapping }}
+        {{ .Values.rolesMapping | toYaml | nindent 8 }}
+        {{- end }}
+      roles.yml: |-
+        _meta:
+          type: "roles"
+          config_version: 2
+        dashboard_read_only:
+          reserved: true
+        security_rest_api_access:
+          reserved: true
+        # Allows users to view monitors, destinations and alerts
+        alerting_read_access:
+          reserved: true
+          cluster_permissions:
+            - 'cluster:admin/opendistro/alerting/alerts/get'
+            - 'cluster:admin/opendistro/alerting/destination/get'
+            - 'cluster:admin/opendistro/alerting/monitor/get'
+            - 'cluster:admin/opendistro/alerting/monitor/search'
+        # Allows users to view and acknowledge alerts
+        alerting_ack_alerts:
+          reserved: true
+          cluster_permissions:
+            - 'cluster:admin/opendistro/alerting/alerts/*'
+        # Allows users to use all alerting functionality
+        alerting_full_access:
+          reserved: true
+          cluster_permissions:
+            - 'cluster_monitor'
+            - 'cluster:admin/opendistro/alerting/*'
+          index_permissions:
+            - index_patterns:
+                - '*'
+              allowed_actions:
+                - 'indices_monitor'
+                - 'indices:admin/aliases/get'
+                - 'indices:admin/mappings/get'
+        # Allow users to read Anomaly Detection detectors and results
+        anomaly_read_access:
+          reserved: true
+          cluster_permissions:
+            - 'cluster:admin/opendistro/ad/detector/info'
+            - 'cluster:admin/opendistro/ad/detector/search'
+            - 'cluster:admin/opendistro/ad/detectors/get'
+            - 'cluster:admin/opendistro/ad/result/search'
+            - 'cluster:admin/opendistro/ad/tasks/search'
+            - 'cluster:admin/opendistro/ad/detector/validate'
+            - 'cluster:admin/opendistro/ad/result/topAnomalies'
+        # Allows users to use all Anomaly Detection functionality
+        anomaly_full_access:
+          reserved: true
+          cluster_permissions:
+            - 'cluster_monitor'
+            - 'cluster:admin/opendistro/ad/*'
+          index_permissions:
+            - index_patterns:
+                - '*'
+              allowed_actions:
+                - 'indices_monitor'
+                - 'indices:admin/aliases/get'
+                - 'indices:admin/mappings/get'
+        # Allows users to read Notebooks
+        notebooks_read_access:
+          reserved: true
+          cluster_permissions:
+            - 'cluster:admin/opendistro/notebooks/list'
+            - 'cluster:admin/opendistro/notebooks/get'
+        # Allows users to all Notebooks functionality
+        notebooks_full_access:
+          reserved: true
+          cluster_permissions:
+            - 'cluster:admin/opendistro/notebooks/create'
+            - 'cluster:admin/opendistro/notebooks/update'
+            - 'cluster:admin/opendistro/notebooks/delete'
+            - 'cluster:admin/opendistro/notebooks/get'
+            - 'cluster:admin/opendistro/notebooks/list'
+        # Allows users to read observability objects
+        observability_read_access:
+          reserved: true
+          cluster_permissions:
+            - 'cluster:admin/opensearch/observability/get'
+        # Allows users to all Observability functionality
+        observability_full_access:
+          reserved: true
+          cluster_permissions:
+            - 'cluster:admin/opensearch/observability/create'
+            - 'cluster:admin/opensearch/observability/update'
+            - 'cluster:admin/opensearch/observability/delete'
+            - 'cluster:admin/opensearch/observability/get'
+        # Allows users to read and download Reports
+        reports_instances_read_access:
+          reserved: true
+          cluster_permissions:
+            - 'cluster:admin/opendistro/reports/instance/list'
+            - 'cluster:admin/opendistro/reports/instance/get'
+            - 'cluster:admin/opendistro/reports/menu/download'
+        # Allows users to read and download Reports and Report-definitions
+        reports_read_access:
+          reserved: true
+          cluster_permissions:
+            - 'cluster:admin/opendistro/reports/definition/get'
+            - 'cluster:admin/opendistro/reports/definition/list'
+            - 'cluster:admin/opendistro/reports/instance/list'
+            - 'cluster:admin/opendistro/reports/instance/get'
+            - 'cluster:admin/opendistro/reports/menu/download'
+        # Allows users to all Reports functionality
+        reports_full_access:
+          reserved: true
+          cluster_permissions:
+            - 'cluster:admin/opendistro/reports/definition/create'
+            - 'cluster:admin/opendistro/reports/definition/update'
+            - 'cluster:admin/opendistro/reports/definition/on_demand'
+            - 'cluster:admin/opendistro/reports/definition/delete'
+            - 'cluster:admin/opendistro/reports/definition/get'
+            - 'cluster:admin/opendistro/reports/definition/list'
+            - 'cluster:admin/opendistro/reports/instance/list'
+            - 'cluster:admin/opendistro/reports/instance/get'
+            - 'cluster:admin/opendistro/reports/menu/download'
+        # Allows users to use all asynchronous-search functionality
+        asynchronous_search_full_access:
+          reserved: true
+          cluster_permissions:
+            - 'cluster:admin/opendistro/asynchronous_search/*'
+          index_permissions:
+            - index_patterns:
+                - '*'
+              allowed_actions:
+                - 'indices:data/read/search*'
+        # Allows users to read stored asynchronous-search results
+        asynchronous_search_read_access:
+          reserved: true
+          cluster_permissions:
+            - 'cluster:admin/opendistro/asynchronous_search/get'
+        # Allows user to use all index_management actions - ism policies, rollups, transforms
+        index_management_full_access:
+          reserved: true
+          cluster_permissions:
+            - "cluster:admin/opendistro/ism/*"
+            - "cluster:admin/opendistro/rollup/*"
+            - "cluster:admin/opendistro/transform/*"
+          index_permissions:
+            - index_patterns:
+                - '*'
+              allowed_actions:
+                - 'indices:admin/opensearch/ism/*'
+        # Allows users to use all cross cluster replication functionality at leader cluster
+        cross_cluster_replication_leader_full_access:
+          reserved: true
+          index_permissions:
+            - index_patterns:
+                - '*'
+              allowed_actions:
+                - "indices:admin/plugins/replication/index/setup/validate"
+                - "indices:data/read/plugins/replication/changes"
+                - "indices:data/read/plugins/replication/file_chunk"
+        # Allows users to use all cross cluster replication functionality at follower cluster
+        cross_cluster_replication_follower_full_access:
+          reserved: true
+          cluster_permissions:
+            - "cluster:admin/plugins/replication/autofollow/update"
+          index_permissions:
+            - index_patterns:
+                - '*'
+              allowed_actions:
+                - "indices:admin/plugins/replication/index/setup/validate"
+                - "indices:data/write/plugins/replication/changes"
+                - "indices:admin/plugins/replication/index/start"
+                - "indices:admin/plugins/replication/index/pause"
+                - "indices:admin/plugins/replication/index/resume"
+                - "indices:admin/plugins/replication/index/stop"
+                - "indices:admin/plugins/replication/index/update"
+                - "indices:admin/plugins/replication/index/status_check"
+        {{- if .Values.roles }}
+        {{ .Values.roles | toYaml | nindent 8 }}
+        {{- end }}
+      config.yml: |-
+        _meta:
+          type: "config"
+          config_version: "2"
+        config:
+          dynamic:
+            http:
+              anonymous_auth_enabled: false
+            authc:
+              basic_internal_auth_domain:
+                description: "Authenticate via HTTP Basic against Internal Users Database"
+                http_enabled: true
+                transport_enabled: true
+                order: "1"
+                http_authenticator:
+                  type: basic
+                  challenge: false
+                authentication_backend:
+                  type: intern
+            
+            {{- if .Values.openid.enabled }}
+              openid_auth_domain:
+                http_enabled: true
+                transport_enabled: true
+                order: 2
+                http_authenticator:
+                  type: openid
+                  challenge: false
+                  config:
+                    subject_key: preferred_username
+                    roles_key: groups
+                    openid_connect_url: "https://iris-iam.stfc.ac.uk/.well-known/openid-configuration"
+                    enable_ssl: true
+                    verify_hostnames: true
+                authentication_backend:
+                  type: noop
+            {{- end }}

--- a/charts/staging/opensearch/values.yaml
+++ b/charts/staging/opensearch/values.yaml
@@ -1,0 +1,151 @@
+opensearch-operator:
+  nameOverride: op
+  installCRDs: true
+
+clusterName: log-storage
+# opensearch and opensearch dashboards version
+# - https://github.com/opensearch-project/OpenSearch/releases
+# - https://github.com/opensearch-project/OpenSearch-Dashboards/releases
+version: 2.17.0
+
+# enable monitoring using opensearch prometheus exporter
+# https://github.com/Aiven-Open/prometheus-exporter-plugin-for-opensearch
+monitoring: 
+  enable: false
+
+# a list of opensearch plugins to enable
+pluginsList: []
+
+# https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/userguide/main.md#smartscaler
+useSmartScaler: false
+
+# opensearch dashboards config
+dashboards:
+  enabled: true
+  replicas: 1
+  ingress:
+    enabled: true
+    ingressClassName: nginx
+    annotations: 
+      nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+      ingress.kubernetes.io/proxy-body-size: "0"
+      nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    hosts:
+      - host: opensearch-dashboards.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: opensearch-tls
+        hosts:
+          - opensearch-dashboards.example.com
+    
+# opensearch clusters are composed of one or more nodepools
+# nodepools represent logical grouping of nodes with the same role
+# see https://opensearch.org/docs/latest/tuning-your-cluster/
+nodePools:
+  - component: nodes
+    replicas: 3
+    diskSize: "1Gi"
+    persistence:
+      pvc:
+        accessModes:
+          - ReadWriteOnce
+        storageClass: longhorn-opensearch
+    nodeSelector: {}
+    roles:
+      - "cluster_manager"
+      - "data"
+    pdb:
+      enable: true
+      maxUnavailable: 1
+  
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  annotations: 
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+  hosts:
+    - host: opensearch.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: opensearch-tls
+      hosts:
+        - opensearch.example.com
+
+# openid is currently only configured to use IRIS IAM
+# NOTE: when setting up IRIS IAM client - the callback should be https://<opensearch-domain>/auth/openid/login 
+openid:
+  enabled: true
+
+# define action groups here
+# https://opensearch.org/docs/latest/security/configuration/yaml/#internal_usersyml
+actiongroups:
+#  myactiongroup:
+#   reserved: false
+#   hidden: false
+#   allowed_actions:
+#   - "indices:data/write/index*"
+#   - "indices:data/write/update*"
+#   - "indices:admin/mapping/put"
+#   - "indices:data/write/bulk*"
+#   - "read"
+#   - "write"
+#   static: false
+
+# define custom tenants here - multi-tenancy is always enabled 
+# https://opensearch.org/docs/latest/security/configuration/yaml/#tenantsyml
+# more about tenants - https://opensearch.org/docs/latest/security/multi-tenancy/tenant-index
+tenants:
+#  prod_tenant:
+#  reserved: false
+#  description: "tenant for production logs"
+
+# define new internal users here
+#https://opensearch.org/docs/latest/security/configuration/yaml/#internal_usersyml
+# recommended to setup reserved users here - those that can't be changed using the REST API or OpenSearch Dashboards
+users:
+#  fluentbit:
+#    hash: THIS SHOULD BE A SECRET - set it in using SOPS
+#    reserved: true
+#    backend_roles:
+#    - "kibana_user"
+#    description: "Fluentbit user for sending logs"
+
+# define roles here
+# https://opensearch.org/docs/latest/security/configuration/yaml/#rolesyml
+roles:
+# prod_log_writer:
+#   reserved: true
+#   cluster_permissions: []
+#   index_permissions:
+#     - index_patterns:
+#         - "prod_kube_logs*"
+#         - "prod_trivy*"
+#       allowed_actions:
+#         - "indices:data/write/index"
+#         - "indices:data/write/bulk"
+#         - "indices:data/write/update"
+#         - "indices:data/write/delete"
+#         - "indices:data/write/create"
+#   tenant_permissions: 
+#     - tenant_patterns:
+#         - "prod"
+#       allowed_actions:
+#         - "kibana_all_read"
+
+# define rolemappings here 
+# https://opensearch.org/docs/latest/security/configuration/yaml/#roles_mappingyml
+# you can map iris-iam groups to roles here 
+rolesMapping:
+  # admin rolemapping - don't delete
+  all_access:
+    reserved: true
+    backend_roles:
+    - "admin"
+    - "stfc-cloud/admins"
+    description: "Maps admin to all_access"

--- a/clusters/staging/worker/chatops-values.yaml
+++ b/clusters/staging/worker/chatops-values.yaml
@@ -1,3 +1,4 @@
+env: staging
 repos:
   stfc:
     - cloud-deployed-apps


### PR DESCRIPTION
- add opensearch chart to staging
- bump cert-manager to 1.15.3
- fix inconsistency with chatops values - `env` needs to be a cluster-specific value

This PR does not affect infrastructure charts like capi/capi-addons. See PR #272
