### PR TITLE
setup rabbit-consumers on argocd

### DIFF
--- a/charts/prod/rabbit-consumers/Chart.yaml
+++ b/charts/prod/rabbit-consumers/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: rabbit-consumers
+version: 1.0.0
+dependencies:
+  - repository: https://stfc.github.io/cloud-helm-charts/
+    name: stfc-cloud-rabbit-consumers
+    version: 1.8.0

--- a/clusters/dev/worker/apps.yaml
+++ b/clusters/dev/worker/apps.yaml
@@ -65,6 +65,12 @@ spec:
             valuesFile: ../../../clusters/dev/worker/opensearch-values.yaml
             secretsFile: ../../../secrets/dev/worker/apps/opensearch.yaml
 
+# TODO: get secrets prepared for dev rabbit consumers
+#          - name: rabbit-consumer
+#            chartName: rabbit-consumer
+#            namespace: rabbit-consumer
+#            valuesFile: ../../../clusters/dev/worker/rabbit-consumer-values.yaml
+
   syncPolicy:
     # Don't remove everything if we remove the appset
     preserveResourcesOnDeletion: true

--- a/clusters/dev/worker/rabbit-consumer-values.yaml
+++ b/clusters/dev/worker/rabbit-consumer-values.yaml
@@ -1,0 +1,23 @@
+
+stfc-cloud-openstack-cluster:
+  consumer:
+    logLevel: DEBUG
+    image:
+      repository: rabbit-consumer
+      tag: local
+      # This allows us to build the image locally and use it in the chart
+      pullPolicy: Never
+
+    aquilon:
+      defaultPrefix: vm-openstack-Dev-
+
+    rabbitmq:
+      host: dev-openstack.stfc.ac.uk
+
+    openstack:
+      authUrl: https://dev-openstack.stfc.ac.uk:5000/v3
+      computeUrl: https://dev-openstack.stfc.ac.uk:8774/v2.1
+      projectId: c9aee696c4b54f12a645af2c951327dc
+
+  kerberosSidecar:
+    principle: "HTTP/dev-service1.nubes.rl.ac.uk"

--- a/clusters/dev/worker/rabbit-consumer-values.yaml
+++ b/clusters/dev/worker/rabbit-consumer-values.yaml
@@ -1,5 +1,5 @@
 
-stfc-cloud-openstack-cluster:
+stfc-cloud-rabbit-consumers:
   consumer:
     logLevel: DEBUG
     image:

--- a/clusters/prod/worker/apps.yaml
+++ b/clusters/prod/worker/apps.yaml
@@ -61,6 +61,11 @@ spec:
             chartName: victoria-metrics
             namespace: victoria-metrics
             valuesFile: ../../../clusters/prod/worker/vicmet-values.yaml
+          
+          - name: rabbit-consumer
+            chartName: rabbit-consumer
+            namespace: rabbit-consumer
+            valuesFile: ../../../clusters/prod/worker/rabbit-consumer-values.yaml
 
 
   syncPolicy:

--- a/clusters/prod/worker/rabbit-consumer-values.yaml
+++ b/clusters/prod/worker/rabbit-consumer-values.yaml
@@ -1,0 +1,15 @@
+stfc-cloud-rabbit-consumers:
+  consumer:
+    aquilon:
+      defaultPrefix: vm-openstack-Prod-
+
+    rabbitmq:
+      host: hv748.nubes.rl.ac.uk
+
+    openstack:
+      authUrl: https://openstack.stfc.ac.uk:5000/v3
+      computeUrl: https://openstack.stfc.ac.uk:8774/v2.1
+      projectId: 4de86830e89b4a46b590536571b6ccd4
+
+  kerberosSidecar:
+    principle: "HTTP/service1.nubes.rl.ac.uk"


### PR DESCRIPTION
point to new rabbitmq node hv748
make prod worker run rabbit consumers

waiting on secrets to be added to dev worker before spinning up rabbit on dev
