### PR TITLE
add github actions to setup automated promotion of charts

### DIFF
--- a/.github/workflows/promote_to_prod.yaml
+++ b/.github/workflows/promote_to_prod.yaml
@@ -1,0 +1,62 @@
+name: Promote Staging to Prod
+
+on:
+  schedule:
+    - cron: '0 12 * * 3'  # Wednesday at 12pm UTC
+  workflow_dispatch:
+
+jobs:
+  create-promotion-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Set branch and PR names
+        id: env-vars
+        run: |
+          echo "branch_name=staging-to-prod-${{ steps.date.outputs.date }}" >> $GITHUB_OUTPUT
+          echo "pr_title=Promote Staging to Prod - ${{ steps.date.outputs.date }}" >> $GITHUB_OUTPUT
+
+      - name: Check for changes
+        id: check-changes
+        run: |
+          if diff -r charts/staging charts/prod > /dev/null; then
+            echo "changes_detected=false" >> $GITHUB_OUTPUT
+          else
+            echo "changes_detected=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Promote Changes
+        if: steps.check-changes.outputs.changes_detected == 'true'
+        run: |
+          rm -rf charts/prod
+          cp -r charts/staging charts/prod
+
+      - name: Commit and Create Pull Request
+        if: steps.check-changes.outputs.changes_detected == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "${{ steps.env-vars.outputs.pr_title }}"
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
+          branch: "${{ steps.env-vars.outputs.branch_name }}"
+          delete-branch: true
+          title: ${{ steps.env-vars.outputs.pr_title }}
+          body: |
+            Automated promotion PR to copy contents from `dev` to `staging`.
+            
+            This PR was automatically created by the environment promotion workflow.
+          base: main
+          labels: |
+            automated
+            environment-promotion
+
+      - name: Log no changes
+        if: steps.check-changes.outputs.changes_detected == 'false'
+        run: echo "No changes detected between staging and prod. Skipping PR creation."

--- a/.github/workflows/promote_to_staging.yaml
+++ b/.github/workflows/promote_to_staging.yaml
@@ -1,0 +1,62 @@
+name: Promote Dev to Staging
+
+on:
+  schedule:
+    - cron: '0 12 * * 2'  # Tuesday at 12pm UTC
+  workflow_dispatch:
+
+jobs:
+  create-promotion-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Set branch and PR names
+        id: env-vars
+        run: |
+          echo "branch_name=dev-to-staging-${{ steps.date.outputs.date }}" >> $GITHUB_OUTPUT
+          echo "pr_title=Promote Dev to Staging - ${{ steps.date.outputs.date }}" >> $GITHUB_OUTPUT
+
+      - name: Check for changes
+        id: check-changes
+        run: |
+          if diff -r charts/dev charts/staging > /dev/null; then
+            echo "changes_detected=false" >> $GITHUB_OUTPUT
+          else
+            echo "changes_detected=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Promote Changes
+        if: steps.check-changes.outputs.changes_detected == 'true'
+        run: |
+          rm -rf charts/staging
+          cp -r charts/dev charts/staging
+
+      - name: Commit and Create Pull Request
+        if: steps.check-changes.outputs.changes_detected == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "${{ steps.env-vars.outputs.pr_title }}"
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
+          branch: "${{ steps.env-vars.outputs.branch_name }}"
+          delete-branch: true
+          title: ${{ steps.env-vars.outputs.pr_title }}
+          body: |
+            Automated promotion PR to copy contents from `dev` to `staging`.
+            
+            This PR was automatically created by the environment promotion workflow.
+          base: main
+          labels: |
+            automated
+            environment-promotion
+
+      - name: Log no changes
+        if: steps.check-changes.outputs.changes_detected == 'false'
+        run: echo "No changes detected between dev and staging. Skipping PR creation."


### PR DESCRIPTION
will automatically promote setup a PR to promote charts from dev-staging and staging-prod

### Description:

<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- If this is a hotfix for production, which needs to be deployed after merging
- If this requires manual work to deploy the PR, e.g. a parameter change
- If this has associated internal documentation too
-->

---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [x] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
