### PR TITLE
Promote victoria metrics chart to staging

### DIFF
--- a/charts/staging/victoria-metrics/values.yaml
+++ b/charts/staging/victoria-metrics/values.yaml
@@ -39,6 +39,7 @@ victoria-metrics-cluster:
   vmstorage:
     retentionPeriod: 1 # month
     replicaCount: 5
+    fullnameOveride: "vmstorage"
 
     persistentVolume:
       enabled: true
@@ -46,3 +47,19 @@ victoria-metrics-cluster:
 
       size: 10Gi
       storageClass: "csi-manila-cephfs"
+    
+    extraContainers:
+      - name: vmbackup
+        image: victoriametrics/vmbackup:v1.96.0
+        command:
+          - "/bin/sh"
+          - "-c"
+          - |
+            echo "vmbackup sidecar running. Use this container for backups."; \
+            while true; do sleep 3600; done
+        volumeMounts:
+          - name: vmstorage-volume # Matches the StatefulSet volume claim name
+            mountPath: /storage
+  
+    podSpec:
+      volumes: [] 


### PR DESCRIPTION
### Description:

Promotion of victoria metrics changes to add vmbackup sidecar 

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- If this is a hotfix for production, which needs to be deployed after merging
- If this requires manual work to deploy the PR, e.g. a parameter change
- If this has associated internal documentation too
-->

---

### Submitter:

Have you:

* [ ] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
