### PR TITLE
don't promote from dev

### DIFF
--- a/.github/workflows/promote_to_staging.yaml
+++ b/.github/workflows/promote_to_staging.yaml
@@ -1,8 +1,6 @@
 name: Promote Dev to Staging
 
 on:
-  schedule:
-    - cron: '0 12 * * 2'  # Tuesday at 12pm UTC
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
dev is volatile and we shouldn't promote from dev to staging on a schedule, instead it should only be manually triggered
