### PR TITLE
Drop action for changed-files

### DIFF
--- a/.github/workflows/pr_copied_files.yaml
+++ b/.github/workflows/pr_copied_files.yaml
@@ -9,14 +9,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - id: changed-files
-        uses: tj-actions/changed-files@v45
-        with:
-          files_yaml: |
-            staging:
-              - charts/staging/**
-            prod:
-              - charts/prod/**
+      - name: Note this flow needs reworking
+        run:
+          echo "Failing until an updated version of this flow is completed"
+          exit 1
+      # - id: changed-files
+      #   uses: tj-actions/changed-files@v45
+      #   with:
+      #     files_yaml: |
+      #       staging:
+      #         - charts/staging/**
+      #       prod:
+      #         - charts/prod/**
 
       - name: Check staging files
         if: steps.changed-files.outputs.staging_any_changed == 'true'


### PR DESCRIPTION
### Description:

This drops the action mentioned in CVE-2025-30066
This is replaced with a step to always fail until new support or a replacement is installed

### Special Notes:

- Security Fix, the GH action is expected to fail with these changes

---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
