### PR TITLE
use alpha chart for materials-galaxy

### DIFF
--- a/charts/dev/materials-galaxy/Chart.yaml
+++ b/charts/dev/materials-galaxy/Chart.yaml
@@ -4,4 +4,4 @@ version: 2.0.0
 dependencies:
   - repository: https://stfc.github.io/cloud-helm-charts/
     name: materials-galaxy
-    version: 2.0.1-alpha.2da10eb
+    version: 2.0.2-alpha.dfedc29

--- a/charts/dev/materials-galaxy/Chart.yaml
+++ b/charts/dev/materials-galaxy/Chart.yaml
@@ -4,4 +4,4 @@ version: 2.0.0
 dependencies:
   - repository: https://stfc.github.io/cloud-helm-charts/
     name: materials-galaxy
-    version: 2.0.2-alpha.dfedc29
+    version: 2.0.2-alpha.97868c8

--- a/clusters/dev/worker/materials-galaxy-values.yaml
+++ b/clusters/dev/worker/materials-galaxy-values.yaml
@@ -33,7 +33,7 @@ materials-galaxy:
         env:
           - name: GITSYNC_REPO
             value: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools.git
-          - name: GITSYNC_BRANCH
+          - name: GITSYNC_REF
             value: main
           - name: GITSYNC_ROOT
             value: "{{.Values.persistence.mountPath}}/git-sync/muon-galaxy-tools"
@@ -66,10 +66,10 @@ materials-galaxy:
             value: "1"
           - name: GITSYNC_REPO
             value: https://github.com/MaterialsGalaxy/larch-tools.git
-          - name: GITSYNC_BRANCH
+          - name: GITSYNC_REF
             value: main
     
-      - name: clf-vepac-tools
+      - name: clone-clf-vepac-tools
         applyToJob: false
         applyToWeb: true
         applyToWorkflow: false

--- a/clusters/dev/worker/materials-galaxy-values.yaml
+++ b/clusters/dev/worker/materials-galaxy-values.yaml
@@ -14,3 +14,180 @@ materials-galaxy:
       - hosts:
           - "galaxy.dev-worker.nubes.stfc.ac.uk" 
         secretName: galaxy-tls
+
+    #- Allow users to specify extra init containers
+    # We use init containers to install tools using git-sync (which aren't available via galaxy toolshed)
+    # TODO: find a better way to do this so we can change tool versions easily
+    extraInitContainers: 
+      - name: clone-muon-tools
+        applyToJob: false
+        applyToWeb: true
+        applyToWorkflow: false
+        image: "registry.k8s.io/git-sync/git-sync:v4.4.0"
+        securityContext:
+          runAsGroup: 0
+          runAsUser: 0
+        volumeMounts:
+          - name: galaxy-data
+            mountPath: "{{.Values.persistence.mountPath}}"
+        env:
+          - name: GITSYNC_REPO
+            value: https://github.com/muon-spectroscopy-computational-project/muon-galaxy-tools.git
+          - name: GITSYNC_BRANCH
+            value: main
+          - name: GITSYNC_ROOT
+            value: "{{.Values.persistence.mountPath}}/git-sync/muon-galaxy-tools"
+          - name: GITSYNC_LINK
+            value: "{{.Values.persistence.mountPath}}/tool-data/muon-galaxy-tools"
+          - name: GITSYNC_ONE_TIME
+            value: "true"
+          - name: GITSYNC_DEPTH
+            value: "1"
+        
+      - name: clone-larch-tools
+        applyToJob: false
+        applyToWeb: true
+        applyToWorkflow: false
+        image: "registry.k8s.io/git-sync/git-sync:v4.4.0"
+        securityContext:
+          runAsGroup: 0
+          runAsUser: 0
+        volumeMounts:
+          - name: galaxy-data
+            mountPath: "{{.Values.persistence.mountPath}}"
+        env:
+          - name: GITSYNC_ROOT
+            value: "{{.Values.persistence.mountPath}}/git-sync/larch-tools"
+          - name: GITSYNC_LINK
+            value: "{{.Values.persistence.mountPath}}/tool-data/larch-tools"
+          - name: GITSYNC_ONE_TIME
+            value: "true"
+          - name: GITSYNC_DEPTH
+            value: "1"
+          - name: GITSYNC_REPO
+            value: https://github.com/MaterialsGalaxy/larch-tools.git
+          - name: GITSYNC_BRANCH
+            value: main
+    
+      - name: clf-vepac-tools
+        applyToJob: false
+        applyToWeb: true
+        applyToWorkflow: false
+        image: "registry.k8s.io/git-sync/git-sync:v4.4.0"
+        command: 
+          - sh
+          - -c 
+          - |
+            mkdir -p /root/.ssh &&\
+            echo "${SSH_PRIVATE_KEY}" > /root/.ssh/id_rsa &&\
+            chmod 600 /root/.ssh/id_rsa &&\
+            exec /git-sync
+        securityContext:
+          runAsGroup: 0
+          runAsUser: 0
+        volumeMounts:
+          - name: galaxy-data
+            mountPath: "{{.Values.persistence.mountPath}}"
+        env:
+          - name: SSH_PRIVATE_KEY
+            valueFrom:
+              secretKeyRef:
+                name: git-deploy-keys
+                key: clf-vepac-key
+          - name: GITSYNC_ROOT
+            value: "{{.Values.persistence.mountPath}}/git-sync/clf-vepac-tools"
+          - name: GITSYNC_LINK
+            value: "{{.Values.persistence.mountPath}}/tool-data/clf-vepac-tools"
+          - name: GITSYNC_ONE_TIME
+            value: "true"
+          - name: GITSYNC_DEPTH
+            value: "1"
+          - name: GITSYNC_REPO
+            value: git@github.com:CLF-vEPAC/Galaxy-tools.git
+          - name: GITSYNC_REF
+            value: dev
+          - name: GITSYNC_SSH
+            value: "true"
+          - name: GITSYNC_SSH_KEY_FILE
+            value: /root/.ssh/id_rsa
+          - name: GITSYNC_SSH_KNOWN_HOSTS
+            value: "false"
+    
+    configs:
+      integrated_tool_panel.xml: |-
+        <?xml version='1.0' encoding='utf-8'?>
+        <toolbox monitor="true">
+          <section id="get_data" name="Get Data">
+          </section>
+          <label id="muon_label" text="Muons" />
+          <section id="muspinsim" name="MuSpinSim">
+          </section>
+          <section id="muon_stopping_sites" name="Muon Stopping Sites">
+          </section>
+          <section id="muon_other" name="Other Muon Tools">
+          </section>
+          <section id="clf_vpac" name="CLF vEPAC Tools">
+          </section>
+          <label id="xas_label" text="xas" />
+          <label id="other_tools" text="Other Tools" />
+          <section id="file_conversion" name="File Conversion">
+          </section>
+          <section id="collection_operations" name="Collection Operations">
+          </section>
+        </toolbox>
+
+      tool_conf.xml: |-
+        <?xml version='1.0' encoding='utf-8'?>
+        <toolbox monitor="true">
+          <section id="get_data" name="Get Data">
+            <tool file="data_source/upload.xml" />
+          </section>
+          <label id="muon_label" text="Muons" />
+          <section id="muspinsim" name="MuSpinSim">
+            <tool file="{{.Values.persistence.mountPath}}/tool-data/muon-galaxy-tools/muspinsim_combine/muspinsim_combine.xml"/>
+            <tool file="{{.Values.persistence.mountPath}}/tool-data/muon-galaxy-tools/muspinsim_config/muspinsim_config.xml"/>
+            <tool file="{{.Values.persistence.mountPath}}/tool-data/muon-galaxy-tools/muspinsim_plot/muspinsim_plot.xml"/>
+            <tool file="{{.Values.persistence.mountPath}}/tool-data/muon-galaxy-tools/muspinsim/muspinsim.xml"/>
+          </section>
+          <section id="muon_stopping_sites" name="Muon Stopping Sites">
+            <tool file="{{.Values.persistence.mountPath}}/tool-data/muon-galaxy-tools/pm_muairss_read/pm_muairss_read.xml"/>
+            <tool file="{{.Values.persistence.mountPath}}/tool-data/muon-galaxy-tools/pm_uep_opt/pm_uep_opt.xml"/>
+            <tool file="{{.Values.persistence.mountPath}}/tool-data/muon-galaxy-tools/pm_symmetry/pm_symmetry.xml"/>
+          </section>
+          <section id="muon_other" name="Other Muon Tools">
+            <tool file="{{.Values.persistence.mountPath}}/tool-data/muon-galaxy-tools/mudirac/mudirac.xml"/>
+            <tool file="{{.Values.persistence.mountPath}}/tool-data/muon-galaxy-tools/pm_asephonons/pm_asephonons.xml"/>
+            <tool file="{{.Values.persistence.mountPath}}/tool-data/muon-galaxy-tools/pm_nq/pm_nq.xml"/>
+          </section>
+          <section id="clf_vepac" name="CLF vEPAC Tools">
+            <tool file="{{.Values.persistence.mountPath}}/tool-data/clf-vepac-tools/geant4-plot/geant4_plot.xml"/>
+            <tool file="{{.Values.persistence.mountPath}}/tool-data/clf-vepac-tools/geant4-sim/geant4_particles.xml"/>
+          </section>
+          <label id="xas_label" text="xas" />
+          <tool file="{{.Values.persistence.mountPath}}/tool-data/larch-tools/larch_select_paths/larch_select_paths.xml" />
+          <tool file="{{.Values.persistence.mountPath}}/tool-data/larch-tools/larch_plot/larch_plot.xml" />
+          <tool file="{{.Values.persistence.mountPath}}/tool-data/larch-tools/larch_athena/larch_athena.xml" />
+          <tool file="{{.Values.persistence.mountPath}}/tool-data/larch-tools/larch_artemis/larch_artemis.xml" />
+          <tool file="{{.Values.persistence.mountPath}}/tool-data/larch-tools/larch_feff/larch_feff.xml" />
+          <tool file="{{.Values.persistence.mountPath}}/tool-data/larch-tools/larch_lcf/larch_lcf.xml" />
+          <tool file="{{.Values.persistence.mountPath}}/tool-data/larch-tools/larch_criteria_report/larch_criteria_report.xml" />
+          <label id="other_tools" text="Other Tools" />
+          <section id="file_conversion" name="File Conversion">
+            <tool file="{{.Values.persistence.mountPath}}/tool-data/muon-galaxy-tools/cif2cell/cif2cell.xml" />
+          </section>
+          <section id="collection_operations" name="Collection Operations">
+            <tool file="${model_tools_path}/tool-data/unzip_collection.xml" />
+            <tool file="${model_tools_path}/tool-data/zip_collection.xml" />
+            <tool file="${model_tools_path}/tool-data/filter_failed_collection.xml" />
+            <tool file="${model_tools_path}/tool-data/filter_empty_collection.xml" />
+            <tool file="${model_tools_path}/tool-data/flatten_collection.xml" />
+            <tool file="${model_tools_path}/tool-data/merge_collection.xml" />
+            <tool file="${model_tools_path}/tool-data/relabel_from_file.xml" />
+            <tool file="${model_tools_path}/tool-data/filter_from_file.xml" />
+            <tool file="${model_tools_path}/tool-data/sort_collection_list.xml" />
+            <tool file="${model_tools_path}/tool-data/tag_collection_from_file.xml" />
+            <tool file="${model_tools_path}/tool-data/apply_rules.xml" />
+            <tool file="${model_tools_path}/tool-data/build_list.xml" />
+            <tool file="${model_tools_path}/tool-data/extract_dataset.xml" />
+          </section>
+        </toolbox>

--- a/clusters/dev/worker/secrets/apps/materials-galaxy.yaml
+++ b/clusters/dev/worker/secrets/apps/materials-galaxy.yaml
@@ -1,4 +1,7 @@
 materials-galaxy:
+    gitRepos:
+        - name: ENC[AES256_GCM,data:H5IdLpzS4Z0u,iv:6YfC70JBV+h6S0AfkKgdPNOpk/Vwx2C2EVSk6j25gwg=,tag:E6CRA5aSEzoEXkrmMwYxSQ==,type:str]
+          deployKey: ENC[AES256_GCM,data:Ofief6ELclRLopykmvWIsd11QQFaOY5p7+xbrtYg8WXENW1Yzk6BrSJZOOldy0j1KrnqrYZ/reFBy9KjP1bqwqK/W6z81n3W6nJvUu1cAifCVstKrIaikMc67qneFyOXHYjU0IGPcjXUylkzPNJ+tRof8Wz++6B7XTWM+YiqTc97R0hWUlqAVJFyAHO3ULnoSc119mTG789zdOXVMJpWTVYjDDfbCNK+5kUimcGdYPE42jeaOuGqD4H3lPf6+y+4op0EO8eSS5D9ExTqAtMflAWQtFv4M3TxkVOkEVztqOFWAmVF3F7YGDFJA0HIqj+XCBozL26OOB6b7tznyma8Id+RdkiS4t6A83Z8UYA1BaKD0YZZd9OcsPJTEmyLj+bjQHNSc71D2lYSjVlHyDxcbYupY0PlFETB7zJEhSfL6uKm2CP5uJHywA0ZPT5ac5rSyLB4mSFqm+U1g2Amk13ArERI5r2m2ch3e9unV8k5U4f1B4wI80eoPFKBujjnw8WQAgA5EvfVkUzt8FWGh8nk0DPTpHNs4lszMM1M9SBWnP0s0cyfTaos2vDMESyOJA==,iv:Poj9OJepp+ZwibKUU8C2ZMmDe9ayoe4ziFOz+W55nxY=,tag:UlMkJzCHUjRp4/hnwAJurg==,type:str]
     oauth2-proxy:
         #ENC[AES256_GCM,data:qNKqEwWBZiSiHV14PejpkpjPbjxo6/uTv3hyHA==,iv:qwCFSVrifvcyVQmYrARxBLW4zqoL4icGRTYTgD0lErk=,tag:rqp22eX3/JJRinciS0rwIQ==,type:comment]
         config:
@@ -97,8 +100,8 @@ sops:
             bHdoV0l3ZFpJaERaUUozS1hKdmxrdTgKqv5ZyOHNf+46hN+SVPB1Ip2Dl/bCZkiA
             29Tqnas+vAUy+uGHIChQXCiR4xDzGicEuuGADsykxu8xGZdn9fwRpA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-01-30T15:04:58Z"
-    mac: ENC[AES256_GCM,data:wD6BpWVoX1dlXEioja67sMPIbgP3rz6VGycqVGASqFYUzQMlnBaIvWVHi7N7FubkUeJcbOn5U7JLE9F+L4fqmefrC7hyQ2a29ypxPfchY2UPlJa0VDKdEQgnIBRKXuFEq5hSmLUiEaH4WclafBkKZ4/z79VEkxQ2w8gMZiYg9+A=,iv:JdRvvW4OK4EnH/oZmMylDJWbufPWGI8WFgj0q5g0lEM=,tag:ELyPVRUoztbxy/DZR8+UbA==,type:str]
+    lastmodified: "2025-05-14T14:13:37Z"
+    mac: ENC[AES256_GCM,data:CsdXKDchIaQqStgjl4upRSW6LxR+Xlg48cocKXHS7LROYY/JPgh3dXd8XSzcvCnArBNNSVPMqhp3TOtDP23NOoAW7ThBvAxPJvZEzZzqo+Rni3zRWSTyhaYbtO+PqoADwxeNhjN7qHYows5Mb+FbDjoxgt3cQALbbfIL9zc2fuI=,iv:6DUpeqDZaYSAwaimiPuncI4W/Y484kBZ8P36yEGX83E=,tag:0C0LflitNc64b+DHKV2kVg==,type:str]
     pgp: []
     unencrypted_regex: ^(apiVersion|metadata|kind|type)$
     version: 3.8.1

--- a/clusters/dev/worker/secrets/apps/materials-galaxy.yaml
+++ b/clusters/dev/worker/secrets/apps/materials-galaxy.yaml
@@ -1,7 +1,7 @@
 materials-galaxy:
     gitRepos:
         - name: ENC[AES256_GCM,data:H5IdLpzS4Z0u,iv:6YfC70JBV+h6S0AfkKgdPNOpk/Vwx2C2EVSk6j25gwg=,tag:E6CRA5aSEzoEXkrmMwYxSQ==,type:str]
-          deployKey: ENC[AES256_GCM,data:Ofief6ELclRLopykmvWIsd11QQFaOY5p7+xbrtYg8WXENW1Yzk6BrSJZOOldy0j1KrnqrYZ/reFBy9KjP1bqwqK/W6z81n3W6nJvUu1cAifCVstKrIaikMc67qneFyOXHYjU0IGPcjXUylkzPNJ+tRof8Wz++6B7XTWM+YiqTc97R0hWUlqAVJFyAHO3ULnoSc119mTG789zdOXVMJpWTVYjDDfbCNK+5kUimcGdYPE42jeaOuGqD4H3lPf6+y+4op0EO8eSS5D9ExTqAtMflAWQtFv4M3TxkVOkEVztqOFWAmVF3F7YGDFJA0HIqj+XCBozL26OOB6b7tznyma8Id+RdkiS4t6A83Z8UYA1BaKD0YZZd9OcsPJTEmyLj+bjQHNSc71D2lYSjVlHyDxcbYupY0PlFETB7zJEhSfL6uKm2CP5uJHywA0ZPT5ac5rSyLB4mSFqm+U1g2Amk13ArERI5r2m2ch3e9unV8k5U4f1B4wI80eoPFKBujjnw8WQAgA5EvfVkUzt8FWGh8nk0DPTpHNs4lszMM1M9SBWnP0s0cyfTaos2vDMESyOJA==,iv:Poj9OJepp+ZwibKUU8C2ZMmDe9ayoe4ziFOz+W55nxY=,tag:UlMkJzCHUjRp4/hnwAJurg==,type:str]
+          deployKey: ENC[AES256_GCM,data:N1MezOaC4ZcFD1w+/uU1RD7vZ6axwhV1x+bZCLUx5jQfaBkFis0deEh8do0V8uBbX0nqRB8dPFv23eaSxO1tWgo9KKbukSkLokyNj5+R8/5+m3pubTyQ/2EM6LO1LwtfkonuerbFA7eW0lZaG0YgEH1NKXRhX9SvlDnc1kgl0ynoN0TNIhok3noZjW2XSP/ezoAYBwFc9DEexCV+6IKXeNOwIsQ7S1dgaynJGLQ0ztD+8QilGw4DPL4TuFJ9frw3nhzKBjJ7Y8Pxtn+18fHHWAIB0YKgI2tXBuWQ0ldNb72v8F7vw+m47+LsZLAYJtrOEOCBzDV9KPghMmvDbZPHeCf3LHs1f0W2J5W7Nf6iSAyfQW4KD/uUvLCt13L1lIJovIrsGC+zQiOJBRxpg3jMCVhmdME2T0P/qIVKaWStXM2CxaWXGVddkeLKv7wzo9lyS97dGDTNgGTHyzOqzKOBghw+iZdnGIgrZeRiCD0q1qB7gd/1qzkGHQrvJl8vK+ODB4+io5kybm0qxiuMhPLlcxV+Qbj4uWcEtYkFNOzpxmaUdg==,iv:2hFbWUby2jGauYuLQyNW8c8RJOLO4DdXb51m3KkzwPs=,tag:h1OH+IdyZ8hJEA1SfI9R3A==,type:str]
     oauth2-proxy:
         #ENC[AES256_GCM,data:qNKqEwWBZiSiHV14PejpkpjPbjxo6/uTv3hyHA==,iv:qwCFSVrifvcyVQmYrARxBLW4zqoL4icGRTYTgD0lErk=,tag:rqp22eX3/JJRinciS0rwIQ==,type:comment]
         config:
@@ -100,8 +100,8 @@ sops:
             bHdoV0l3ZFpJaERaUUozS1hKdmxrdTgKqv5ZyOHNf+46hN+SVPB1Ip2Dl/bCZkiA
             29Tqnas+vAUy+uGHIChQXCiR4xDzGicEuuGADsykxu8xGZdn9fwRpA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-05-14T14:13:37Z"
-    mac: ENC[AES256_GCM,data:CsdXKDchIaQqStgjl4upRSW6LxR+Xlg48cocKXHS7LROYY/JPgh3dXd8XSzcvCnArBNNSVPMqhp3TOtDP23NOoAW7ThBvAxPJvZEzZzqo+Rni3zRWSTyhaYbtO+PqoADwxeNhjN7qHYows5Mb+FbDjoxgt3cQALbbfIL9zc2fuI=,iv:6DUpeqDZaYSAwaimiPuncI4W/Y484kBZ8P36yEGX83E=,tag:0C0LflitNc64b+DHKV2kVg==,type:str]
+    lastmodified: "2025-05-15T12:09:06Z"
+    mac: ENC[AES256_GCM,data:7Pn2hHq4d6MF98nILP6oiMs+x8KWw38ZD/D81nCde0j9ksfvB0c0HAHL7ymt2AeNwO9pWZDHkpip3KU+oSsJItQ7cpHpAuvFFV+7U9gepwK1+7ZJQAkh3FtNpPN2MV2ljM9MCwVJiJPX8j7L/mMgPJb4R3xlR3idpHNkPWU5SYs=,iv:d+nXgJ+ffGFoT09Yg+QUqS495LVcqXbEYhmmMBA+LO4=,tag:vtWjB8Q3svopEIew4m/xfw==,type:str]
     pgp: []
     unencrypted_regex: ^(apiVersion|metadata|kind|type)$
     version: 3.8.1


### PR DESCRIPTION
use git-sync to manage latest local versions of repos containing galaxy tools.
Now a simple restart of the galaxy web container is all that's needed to pick up changes from various repos

Moved repo configuration here because that's likely going to need to be changed consistently

deploy's changed made in this PR - https://github.com/stfc/cloud-helm-charts/pull/15