### PR TITLE
bump argo major version 7.8.0 - 8.0.2

### DIFF
--- a/charts/dev/argocd/Chart.yaml
+++ b/charts/dev/argocd/Chart.yaml
@@ -4,5 +4,5 @@ version: 1.0.1
 dependencies:
   # https://github.com/argoproj/argo-helm/releases
   - name: argo-cd
-    version: 7.8.0
+    version: 8.0.2
     repository: https://argoproj.github.io/argo-helm


### PR DESCRIPTION
tested and working
- will require a rebuild of dev worker and management clusters by removing argo namespae and running `./deploy.sh` again - should not disrupt any other services
