### PR TITLE
bug: set staging app-of-apps serversideapply=true

### DIFF
--- a/clusters/staging/worker/apps.yaml
+++ b/clusters/staging/worker/apps.yaml
@@ -112,6 +112,7 @@ spec:
           allowEmpty: true
         syncOptions:
           - CreateNamespace=true
+          - ServerSideApply=true
 
   templatePatch: |
     {{- if eq .name "manila-csi" }}


### PR DESCRIPTION
issue with galaxy postgresql label being too big solved with argocd serversideapply=true
