### PR TITLE
Bump ArgoCD charts to latest version (minor)

### DIFF
--- a/charts/dev/argocd/Chart.yaml
+++ b/charts/dev/argocd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: argocd
-version: 1.0.1
+version: 1.0.2
 dependencies:
   # https://github.com/argoproj/argo-helm/releases
   - name: argo-cd
-    version: 8.0.2
+    version: 8.0.14
     repository: https://argoproj.github.io/argo-helm


### PR DESCRIPTION
### Description:

Bumps the ArgoCD charts to the latest minor version 8.0.14 to get us to the latest patch version, this keeps us on the 3.x series so no major changes are required elsewhere

Releases can be found here: https://github.com/argoproj/argo-helm/releases?q=&expanded=true

### Special Notes:

<!-- This section and header can be removed if not required.

---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
