### PR TITLE
MAINT: Bump chart dependencies on dev

### DIFF
--- a/charts/dev/capi-infra/Chart.yaml
+++ b/charts/dev/capi-infra/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: capi-infra
-version: 2.0.0
+version: 2.0.1
 dependencies:
   - repository: https://stfc.github.io/cloud-helm-charts/
     name: stfc-cloud-openstack-cluster
-    version: 1.4.4
+    version: 1.4.5

--- a/charts/dev/longhorn/Chart.yaml
+++ b/charts/dev/longhorn/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: longhorn
-version: 2.0.0
+version: 2.0.1
 dependencies:
   - repository: https://stfc.github.io/cloud-helm-charts/
     name: stfc-cloud-longhorn
-    version: 1.0.1
+    version: 1.0.2

--- a/charts/dev/materials-galaxy/Chart.yaml
+++ b/charts/dev/materials-galaxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: materials-galaxy
-version: 2.0.0
+version: 2.0.1
 dependencies:
   - repository: https://stfc.github.io/cloud-helm-charts/
     name: materials-galaxy
-    version: 2.1.0
+    version: 2.1.2


### PR DESCRIPTION
### Description:

Bump dependency chart versions on dev
---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
