### PR TITLE
MAINT: Bump capi addon provider minor on dev

### DIFF
--- a/charts/dev/cluster-api-addon-provider/Chart.yaml
+++ b/charts/dev/cluster-api-addon-provider/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v2
 name: cluster-api-addon-provider
 version: 1.2.0 
 dependencies:
+  # https://github.com/azimuth-cloud/cluster-api-addon-provider/releases
   - repository: https://azimuth-cloud.github.io/cluster-api-addon-provider
     name: cluster-api-addon-provider
-    version: 0.7.2
+    version: 0.8.2


### PR DESCRIPTION
### Description:

Bump CAPI addons minor version on dev

---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
