### PR TITLE
Set up harbor specific ingress for staging

### DIFF
--- a/charts/dev/argocd/values.yaml
+++ b/charts/dev/argocd/values.yaml
@@ -28,8 +28,6 @@ argo-cd:
         # This is overriden per-cluster in the cluster's argo-values.yaml
         name: "self-signed"
 
-
-
   # Inject Helm-Secrets into the ArgoCD server
   repoServer:
     env:

--- a/charts/dev/harbor/Chart.yaml
+++ b/charts/dev/harbor/Chart.yaml
@@ -5,3 +5,7 @@ dependencies:
   - name: stfc-cloud-harbor
     version: 1.1.3
     repository: https://stfc.github.io/cloud-helm-charts
+  - name: ingress-nginx
+    version: "4.12.3"
+    repository: "https://kubernetes.github.io/ingress-nginx"
+    alias: ingress-nginx-harbor

--- a/charts/staging/argocd/values.yaml
+++ b/charts/staging/argocd/values.yaml
@@ -28,8 +28,6 @@ argo-cd:
         # This is overriden per-cluster in the cluster's argo-values.yaml
         name: "self-signed"
 
-
-
   # Inject Helm-Secrets into the ArgoCD server
   repoServer:
     env:

--- a/charts/staging/harbor/Chart.yaml
+++ b/charts/staging/harbor/Chart.yaml
@@ -5,3 +5,7 @@ dependencies:
   - name: stfc-cloud-harbor
     version: 1.1.3
     repository: https://stfc.github.io/cloud-helm-charts
+  - name: ingress-nginx
+    version: "4.12.3"
+    repository: "https://kubernetes.github.io/ingress-nginx"
+    alias: ingress-nginx-harbor

--- a/clusters/staging/worker/argocd-setup-values.yaml
+++ b/clusters/staging/worker/argocd-setup-values.yaml
@@ -2,9 +2,14 @@ argo-cd:
   global:
     domain: argocd.staging-worker.nubes.stfc.ac.uk
 
+  server:
+    ingress:
+      ingressClassName: internal-nginx
+
 stfc-cloud-longhorn:
   longhorn:
     ingress:
+      ingressClassName: internal-nginx
       host: "longhorn.staging-worker.nubes.stfc.ac.uk"
     persistence:
       # can't be set for RWX

--- a/clusters/staging/worker/harbor-values.yaml
+++ b/clusters/staging/worker/harbor-values.yaml
@@ -1,11 +1,12 @@
 stfc-cloud-harbor:
   harbor:
-    externalURL: "https://harbor.staging-worker.nubes.stfc.ac.uk"
+    externalURL: "https://staging.harbor.stfc.ac.uk"
 
     expose:
       ingress:
+        className: ingress-nginx-harbor
         hosts:
-          core: "harbor.staging-worker.nubes.stfc.ac.uk"
+          core: "staging.harbor.stfc.ac.uk"
 
     database:
       type: external
@@ -21,3 +22,19 @@ stfc-cloud-harbor:
       weekly: "s3://staging-harbor-backup/weekly"
       monthly: "s3://staging-harbor-backup/monthly"
     endpoint: "https://s3.echo.stfc.ac.uk"
+
+ingress-nginx-harbor:
+  controller:
+    electionID: harbor-ingress-controller-leader
+    ingressClass: ingress-nginx-harbor
+    ingressClassResource:
+      name: ingress-nginx-harbor
+      enabled: true
+      default: false
+      controllerValue: "k8s.io/ingress-nginx-harbor"
+    service:
+      annotations:
+        # Don't delete the floating ip when deleting loadbalancers
+        # prevents errors when deleting clusters, leave as true
+        loadbalancer.openstack.org/keep-floatingip: true
+      loadBalancerIP: "130.246.81.227"

--- a/clusters/staging/worker/infra-values.yaml
+++ b/clusters/staging/worker/infra-values.yaml
@@ -12,7 +12,7 @@ stfc-cloud-openstack-cluster:
 
     nodeGroupDefaults:
       machineFlavor: dep-l2.tiny
-      nodeLabels:	
+      nodeLabels:
         # we're running longhorn on this cluster
         # set label so worker nodes can host longhorn volumes
         longhorn.store.nodeselect/longhorn-storage-node: true
@@ -24,14 +24,25 @@ stfc-cloud-openstack-cluster:
           release:
             values:
               controller:
+                electionID: ingress-controller-leader
+                ingressClass: internal-nginx
+                ingressClassResource:
+                  name: internal-nginx
+                  enabled: true
+                  default: true
+                  controllerValue: "k8s.io/ingress-internal-nginx"
                 service:
+                  annotations:
+                    # Don't delete the floating ip when deleting loadbalancers
+                    # prevents errors when deleting clusters, leave as true
+                    loadbalancer.openstack.org/keep-floatingip: true
                   loadBalancerIP: "130.246.81.242"
 
       monitoring:
         enabled: true
-        # no need to send alerts around certs/openstack API endpoints for dev/staging clusters 
+        # no need to send alerts around certs/openstack API endpoints for dev/staging clusters
         # ends up with too many messages in the ticket queue
-        blackBoxExporter: 
+        blackBoxExporter:
           enabled: false
         kubePrometheusStack:
           release:
@@ -42,6 +53,7 @@ stfc-cloud-openstack-cluster:
                     cluster: worker
                     env: staging
                 ingress:
+                  ingressClassName: internal-nginx
                   hosts:
                     - prometheus.staging-worker.nubes.stfc.ac.uk
                   tls:
@@ -50,6 +62,7 @@ stfc-cloud-openstack-cluster:
                       secretName: tls-keypair
               grafana:
                 ingress:
+                  ingressClassName: internal-nginx
                   hosts:
                     - grafana.staging-worker.nubes.stfc.ac.uk
                   tls:
@@ -59,6 +72,7 @@ stfc-cloud-openstack-cluster:
               alertmanager:
                 enabled: true
                 ingress:
+                  ingressClassName: internal-nginx
                   hosts:
                     - alertmanager.staging-worker.nubes.stfc.ac.uk
                   tls:

--- a/clusters/staging/worker/materials-galaxy-values.yaml
+++ b/clusters/staging/worker/materials-galaxy-values.yaml
@@ -1,4 +1,3 @@
-
 materials-galaxy:
   oauth2-proxy:
     extraArgs:
@@ -6,19 +5,20 @@ materials-galaxy:
 
   galaxy:
     ingress:
+      ingressClassName: internal-nginx
       hosts:
-      - host: "galaxy.staging-worker.nubes.stfc.ac.uk"
-        paths:
-          - path: "/"
+        - host: "galaxy.staging-worker.nubes.stfc.ac.uk"
+          paths:
+            - path: "/"
       tls:
-      - hosts:
-          - "galaxy.staging-worker.nubes.stfc.ac.uk" 
-        secretName: galaxy-tls
+        - hosts:
+            - "galaxy.staging-worker.nubes.stfc.ac.uk"
+          secretName: galaxy-tls
 
     #- Allow users to specify extra init containers
     # We use init containers to install tools using git-sync (which aren't available via galaxy toolshed)
     # TODO: find a better way to do this so we can change tool versions easily
-    extraInitContainers: 
+    extraInitContainers:
       - name: clone-muon-tools
         applyToJob: false
         applyToWeb: true
@@ -43,7 +43,7 @@ materials-galaxy:
             value: "true"
           - name: GITSYNC_DEPTH
             value: "1"
-        
+
       - name: clone-larch-tools
         applyToJob: false
         applyToWeb: true
@@ -68,15 +68,15 @@ materials-galaxy:
             value: https://github.com/MaterialsGalaxy/larch-tools.git
           - name: GITSYNC_REF
             value: main
-    
+
       - name: clone-clf-vepac-tools
         applyToJob: false
         applyToWeb: true
         applyToWorkflow: false
         image: "registry.k8s.io/git-sync/git-sync:v4.4.0"
-        command: 
+        command:
           - sh
-          - -c 
+          - -c
           - |
             mkdir -p /root/.ssh &&\
             echo "${SSH_PRIVATE_KEY}" > /root/.ssh/id_rsa &&\
@@ -112,7 +112,7 @@ materials-galaxy:
             value: /root/.ssh/id_rsa
           - name: GITSYNC_SSH_KNOWN_HOSTS
             value: "false"
-    
+
     configs:
       integrated_tool_panel.xml: |-
         <?xml version='1.0' encoding='utf-8'?>

--- a/clusters/staging/worker/vicmet-values.yaml
+++ b/clusters/staging/worker/vicmet-values.yaml
@@ -1,1 +1,12 @@
-#Placeholder file for cluster specific values
+stfc-cloud-vm:
+  vmselect:
+    ingress:
+      ingressClassName: internal-nginx
+      annotations:
+        kubernetes.io/ingress.class: "internal-nginx"
+
+  vminsert:
+    ingress:
+      ingressClassName: internal-nginx
+      annotations:
+        kubernetes.io/ingress.class: "internal-nginx"


### PR DESCRIPTION
Rename default ingressclass to internal-nginx
Point other services to use internal-nginx
Create 2nd ingressclass for harbor
Update staging harbor url and floating ip

### Description:

<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- If this is a hotfix for production, which needs to be deployed after merging
- If this requires manual work to deploy the PR, e.g. a parameter change
- If this has associated internal documentation too
-->

---

### Submitter:

Have you:

* [ ] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
