### PR TITLE
Monitoring basic auth

### DIFF
--- a/clusters/dev/management/apps.yaml
+++ b/clusters/dev/management/apps.yaml
@@ -126,6 +126,7 @@ spec:
             # Bring in infra secrets specific to this cluster
             - "secrets://../../../clusters/{{path[1]}}/{{path[2]}}/secrets/infra/api-server-fip.yaml"
             - "secrets://../../../clusters/{{path[1]}}/{{path[2]}}/secrets/infra/app-creds.yaml"
+            - "secrets://../../../clusters/{{path[1]}}/{{path[2]}}/secrets/infra/basic-auth.yaml"
 
       syncPolicy:
         automated:

--- a/clusters/dev/management/infra-values.yaml
+++ b/clusters/dev/management/infra-values.yaml
@@ -12,9 +12,9 @@ stfc-cloud-openstack-cluster:
                   loadBalancerIP: "130.246.211.178"
 
       monitoring:
-        # no need to send alerts around certs/openstack API endpoints for dev/staging clusters 
+        # no need to send alerts around certs/openstack API endpoints for dev/staging clusters
         # ends up with too many messages in the ticket queue
-        blackBoxExporter: 
+        blackBoxExporter:
           enabled: false
         kubePrometheusStack:
           release:
@@ -25,6 +25,10 @@ stfc-cloud-openstack-cluster:
                     cluster: management
                     env: dev
                 ingress:
+                  annotations:
+                    nginx.ingress.kubernetes.io/auth-type: basic
+                    nginx.ingress.kubernetes.io/auth-secret: monitoring-auth
+                    nginx.ingress.kubernetes.io/auth-realm: "Authentication Required - Dev Management"
                   hosts:
                     - prometheus.dev-mgmt.nubes.stfc.ac.uk
                   tls:
@@ -33,6 +37,10 @@ stfc-cloud-openstack-cluster:
                       secretName: tls-keypair
               grafana:
                 ingress:
+                  annotations:
+                    nginx.ingress.kubernetes.io/auth-type: basic
+                    nginx.ingress.kubernetes.io/auth-secret: monitoring-auth
+                    nginx.ingress.kubernetes.io/auth-realm: "Authentication Required - Dev Management"
                   hosts:
                     - grafana.dev-mgmt.nubes.stfc.ac.uk
                   tls:
@@ -42,9 +50,13 @@ stfc-cloud-openstack-cluster:
               alertmanager:
                 enabled: true
                 ingress:
+                  annotations:
+                    nginx.ingress.kubernetes.io/auth-type: basic
+                    nginx.ingress.kubernetes.io/auth-secret: monitoring-auth
+                    nginx.ingress.kubernetes.io/auth-realm: "Authentication Required - Dev Management"
                   hosts:
                     - alertmanager.dev-mgmt.nubes.stfc.ac.uk
                   tls:
                     - hosts:
                         - alertmanager.dev-mgmt.nubes.stfc.ac.uk
-                      secretName: tls-keypair                
+                      secretName: tls-keypair

--- a/clusters/dev/management/secrets/infra/basic-auth.yaml
+++ b/clusters/dev/management/secrets/infra/basic-auth.yaml
@@ -1,0 +1,104 @@
+stfc-cloud-openstack-cluster:
+    openstack-cluster:
+        addons:
+            monitoring:
+                kubePrometheusStack:
+                    release:
+                        values:
+                            prometheus:
+                                extraSecret:
+                                    name: ENC[AES256_GCM,data:Z+KVtcu4rXpMVA==,iv:/UPgd5eKVb4m1gO3jCE3qlyNbb6vjwmUW2zdmiXMEdU=,tag:FCgtUr6UnYet+xzvSOqAyg==,type:str]
+                                    data:
+                                        auth: ENC[AES256_GCM,data:lxbXkJQH0G8qw5kOIb/kk4O/dIiowjHR7lagRunIDQL2Km9+Z+QfHsl6ig==,iv:pMZMkwG+FA9dzG4n8lp6h20YWEg1QVtvYRa+D0Y/8EQ=,tag:EYT4bRqYsPUm/IhZw2KH0A==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1xr298hh8ammzethfcdeh72c25wnrk3u2zlzxx78k4nfcq2rwpgqs9hljq8
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6c0lFdXVCOWlpd0dEc1hw
+            cCtLMS9OME1NUDZnREN3aVc3NW0rd2NFY0VRCnlVR3IrbElhS1dFTzc1Tlk0TUpO
+            aktVdHF4MTFMdWlLVnFvbkJkTjZ4ek0KLS0tIHlzZ0FscHFnRWxDc29JNW85K2Rt
+            NVNvRXBaVnd5dnhyeVVSRUR5VjdvVWMKKEpojKROe+nJQdtM4tOhKeFiYJfyP13g
+            fhnRjNVcEmu/s2EcHznXLEDkJxdERDF85VZ0Jf1oWdIS03pmjzSujw==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1acqcungzwkt807d3jt94ngtdt0vhk9kec4ps4a22cpaah57jw4xsl7q4xc
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSNFMzb2VnSEhwMzhMYmFJ
+            TGhQanM1bWFETENXRk00VXJsUTdQSUhKaURFCmQ1a1JTOVk2VXVlNnNrVHp1UGRE
+            aUdnRkpqbERuMjlndW0xeitaTWVhbmsKLS0tIFRUY3owRmI2eXc5czA5UlowNnJn
+            SUMvYmErT1ZiVXNZYWJTUWVHazh6elEKomnzh4JwKQKgs3RkiDeyu3J6P7OSuQQ4
+            XevGBZgZpjKsfma2F8W1BEtx7WCxu4eeOqKB2UNNktBaN1z7ysMneQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1h3dmygqf4v6jg3nxk5sr9jkp27w3q83sqnqxdd5n92xf3w6fs5kshakrxn
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPUG95dVZvOUtiYUx1Vkh6
+            SDM5ZjljVFBjTGpKYWZXa0V2NWxjRnFPMkdrCjcwQjNNUVdqZzJkMm9IU2VxbFJJ
+            c0JuaEJLY3NJRWk4NGtzQjJFL0ltQmcKLS0tIFE3b0JJbXNKSEdSazFNWW1tek0x
+            L0xuN2FDZGNmMTlVUk9PaThYemtvbGMKbxpm5fcCJ2yJmgw0BuOzEWbCetceKKwE
+            2JeGZ4ugx7a/DN60/3aFGMnB8RrdGWNmou8/ca+CwMFe5AP1lLHW1Q==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age12khufkd7z25eqgpjjyy0zcrq6kpjxzekmff5zhq7q54tajm4e58qul35x0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWY1l1OGZFbTFjNjZPYTZO
+            K09rSStnR0ZSL0hINVZneEtkWmdyZDNTTGlvCitSTCtTcWsrKys4VlV0OHBITWdP
+            N0FHRWQ3em9lT0V0NWoxenRZcFFnWm8KLS0tIDY5aTQrbWZGcThlMG0xNjB2MXJw
+            WmdBMFFtL2RzckpTb0dYQ2JJclBuNDgKMeQsB38Nrx/GHVZgJcg+HXD5fNUrFwnr
+            hXgZUo7p6MjSh1HwFTk1Tc5K+qkQLx9pnjhF6NGPBk9sv9YL199ktQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age16fufeddr0arrns268526gxethxgkh3g0euf8cn37kuwfmq3h23psutz4q8
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvcWptSHJCSUxHZ29tTTEv
+            WHZRbEIrOERKSGd2VUdRYW81OU1ac0pEZmxRCkVVaVlMaTVMZFV2M3RqRDV3YzRY
+            aDdnTFk1cGtvVmY0WUxxMnBvUlgwZWsKLS0tIDkxYVQ4QWUzZ2xSOTNRWTg2VkNU
+            UEs2ZUtXSkhBYWlMakhmcWkwU2RjZE0KruFZ9AiUDqZLJwgor+saUFwnFvAlP6A+
+            Tjl/3X2f4x0M7gHGiON4Dt1BIViVvL0g8IRBUU4Zyr0Gn7zafvY5cA==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1a8e4gxw67kp27s3hssfxyem3e8jwaha3huz0sttfngeu60pk5pxqkfpg3d
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZd1VrZjYyMmZVS01ad0Z4
+            VXkyNVVMYjNWQTNjWFl2U1B5MXpBTFFBV0R3CjZ0Q0lRSnpDSmlsWHNlZG0rNDFy
+            MWw1Zk9YL0JEZkxJaGFLak45SFJTdFkKLS0tIHVKZjZFdWVJRDVOcTQyaWFuNDNZ
+            UnZObVdVeXRrQk9kUUUzdnhPUVl1MVkK7Ed7rO74Y/FMCk2Z9LaJcgvzwH/a0QWB
+            HXIXlQEKIunbF5DKdDxA2ZM9u/p77JrwMdPNg215raOcqIx72/G/0g==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1drky6caal0j2x58yzpw9tyflcpdpmcjqy8nss7zfvspszg0xfpdsyzu8s4
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzajIvMlN0L1pUMW1HUnYx
+            UmVPR3ZMQ0N5WWIzcVl2Z3V5Y0tTWXk0cWdVCjlqaHRSeUNzZ2VkMGNkN3dtZXNj
+            ajlKbWJ3VGY5QW10dENzSlpPQ1dUQkkKLS0tIHVVQW9uR1NlNllJdEZ5UmpTTjNo
+            NXVxTElFMFpXNWI4Z2dYVm8wNUV0MkUKThAI+Aq+aTLgjc0m0scttgr3eTYr13cs
+            IfMYkLIDYspbnqlqvapXiyZbYc3Bq13HnOggsZK9u5foGLMYEkEmvw==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1m57vjw60dpr02ghka8kh2xlqsa0ggxauau2y488zdh89vu760qgqh8lcge
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzTlRFdmc4KzNqTkFoTGpQ
+            M3orS3B5cCthYi9xZVAzcFVyOUFBcDZXUHdJCmx2R24vVE1kVno3cjlTVGdqVHlW
+            UUR2UG5BRWtpdDdMY2xmTEIzNSt2dmMKLS0tIC9Ia25oTUVHZjZNaU9SUFhXNmp3
+            NEIxYUl3MDRrWVNqdHgrZndSWjEzMEEKdXvHxV0fETA7IWBp7HjSw/eRP6D1M+F/
+            JGr2+sMIfRoDIfOjscQZkQp7WNe9OVYAWTuhqo8j6rmYSpIPf77ZzA==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1cmq75nz6rxancqlj7g7r2pum8c9xlznuetslmjmthk2g9p4flgdqz0tv8g
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwb05YeVFCUWJNZmQxUWxF
+            czlCYTVTM1MrNVowUnJISDY5ckdUUEI1WEh3CmxWcXRZMVprSEJyMUlmN3BzZFht
+            ZDliWERkdVpvYkdEVndvZWUzZUhKQjAKLS0tIFNKbThEOE5sQ2tQeHRuVERoQWZm
+            YlplaGNNZHpqRjhEYTZsNVk2SlllUVkKphicER6vljMQh4aipOh/ibJkL9Afh6u2
+            d6TGCyMRooZG/3mZbXKlGqvmaM8lPojP76emuZm6/WJfznBMfxX/QQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-06-18T08:11:59Z"
+    mac: ENC[AES256_GCM,data:cWT+JTOcl86rJhnrO2in/v5WYgG1HYCV0czkixmYVd5nmkYGakkwzCL1duaaQAZI5MpBzkHXYMzzweCg5yZYHjRi+azYcXURbyeOJs0hl9SKd/ahNu2xnWQjRX5HWofmuV18SkRoCAQAiGm3jYSCLid/pS1zQ/z2ZozZstk8Aao=,iv:Hn053qpMyTvXU7M0WQjeiOrmj5uSC70DGsZMsguTI5c=,tag:v90rFEGjT/j1PHSvehb8Kw==,type:str]
+    pgp: []
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.9.0

--- a/clusters/dev/worker/infra-values.yaml
+++ b/clusters/dev/worker/infra-values.yaml
@@ -2,7 +2,7 @@ stfc-cloud-openstack-cluster:
   openstack-cluster:
     cloudCredentialsSecretName: dev-worker-cluster-cloud-credentials
     nodeGroupDefaults:
-      nodeLabels:	
+      nodeLabels:
         # we're running longhorn on this cluster
         # set label so worker nodes can host longhorn volumes
         longhorn.store.nodeselect/longhorn-storage-node: true
@@ -19,9 +19,9 @@ stfc-cloud-openstack-cluster:
 
       monitoring:
         enabled: true
-        # no need to send alerts around certs/openstack API endpoints for dev/staging clusters 
+        # no need to send alerts around certs/openstack API endpoints for dev/staging clusters
         # ends up with too many messages in the ticket queue
-        blackBoxExporter: 
+        blackBoxExporter:
           enabled: false
         kubePrometheusStack:
           release:
@@ -32,23 +32,35 @@ stfc-cloud-openstack-cluster:
                     cluster: worker
                     env: dev
                 ingress:
+                  annotations:
+                    nginx.ingress.kubernetes.io/auth-type: basic
+                    nginx.ingress.kubernetes.io/auth-secret: monitoring-auth
+                    nginx.ingress.kubernetes.io/auth-realm: "Authentication Required - Dev Worker"
                   hosts:
                     - prometheus.dev-worker.nubes.stfc.ac.uk
                   tls:
-                    - hosts: 
-                      - prometheus.dev-worker.nubes.stfc.ac.uk
+                    - hosts:
+                        - prometheus.dev-worker.nubes.stfc.ac.uk
                       secretName: tls-keypair
               grafana:
                 ingress:
+                  annotations:
+                    nginx.ingress.kubernetes.io/auth-type: basic
+                    nginx.ingress.kubernetes.io/auth-secret: monitoring-auth
+                    nginx.ingress.kubernetes.io/auth-realm: "Authentication Required - Dev Worker"
                   hosts:
                     - grafana.dev-worker.nubes.stfc.ac.uk
                   tls:
-                    - hosts: 
-                      - grafana.dev-worker.nubes.stfc.ac.uk
+                    - hosts:
+                        - grafana.dev-worker.nubes.stfc.ac.uk
                       secretName: tls-keypair
               alertmanager:
                 enabled: true
                 ingress:
+                  annotations:
+                    nginx.ingress.kubernetes.io/auth-type: basic
+                    nginx.ingress.kubernetes.io/auth-secret: monitoring-auth
+                    nginx.ingress.kubernetes.io/auth-realm: "Authentication Required - Dev Worker"
                   hosts:
                     - alertmanager.dev-worker.nubes.stfc.ac.uk
                   tls:

--- a/clusters/dev/worker/secrets/infra/basic-auth.yaml
+++ b/clusters/dev/worker/secrets/infra/basic-auth.yaml
@@ -1,0 +1,104 @@
+stfc-cloud-openstack-cluster:
+    openstack-cluster:
+        addons:
+            monitoring:
+                kubePrometheusStack:
+                    release:
+                        values:
+                            prometheus:
+                                extraSecret:
+                                    name: ENC[AES256_GCM,data:5sqzTkaf/TJTFw==,iv:blepCwShn+Cg12dvWiPIvzwnwKZAgAJMtKyPRATZNNM=,tag:sqXTm3vy8mGfhPBIeMSjeQ==,type:str]
+                                    data:
+                                        auth: ENC[AES256_GCM,data:z/m7UBoNCki8hD+nMRyINClr81qydnSaj67/qtMIcJDW8X+4kWz/TC/nDA==,iv:J5PFCQddmXszJDlJc9jFx/aiQQkDDVKd29OkanbJe28=,tag:2N8ewbNH9xUdPfjDt/BgVQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1xr298hh8ammzethfcdeh72c25wnrk3u2zlzxx78k4nfcq2rwpgqs9hljq8
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1RnhlV2pkYlljcDFhOXE0
+            aTlCaGxwN0tCMERESmhaalB2dE9sazlSTkJnCktkS1hwZ0pZRU5CNHZDYXZoS0lm
+            VHE1czY0QlRJWWF1T1lUMkFhTGNVeXMKLS0tIHlici9yVTlBbXhVMkZFT2ZvQkxa
+            YnhBUGRSZkdkSXhBZjI2QWpuNml5TFEKuQIzMHbABlpL9x1KZO6eTdO5/R+0loDn
+            OsHik0ohGlvHpVabvK7uwXLFz0ZGAVUCF+g9oj8ZdtpFPlxHiRn0nQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1acqcungzwkt807d3jt94ngtdt0vhk9kec4ps4a22cpaah57jw4xsl7q4xc
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1Z3Z4RWZRNHdPNEtiSG81
+            MGpvQXFDZnRzM3RoTUMyMk4zbXRrOGhIZmlrCldQUjZvNlhkaWM2T1hqUGRHTVh4
+            R2k5bDQ4QW9nQ0hqTjQzZ2lnZnNBWGcKLS0tIGgvRURQaXJZaThNUE0rMmNqTWhE
+            eFJZeEIxOFFPTXhTZDBGeHZ1Rm9xeUUKU9d6IDK5P/5EF/pdjbUJH3WXZ1CG67+d
+            Vw316fsaTJwYYjj7mfpy5woh96uaefqoJ5IsVEEWT22Zevi8Z6jB8g==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1h3dmygqf4v6jg3nxk5sr9jkp27w3q83sqnqxdd5n92xf3w6fs5kshakrxn
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMZlpwZ203Rld1VVREMTk3
+            Q0FBVDdMSFdaczNDelJEMk1SOC9QL0pFWG1rClZ1UzJXa1kwTjlMbHVwRW5UVzRB
+            Yko2ZktyRXNEOWVyYkg3WGVXclUxNmMKLS0tIDg0RWVJODdMVm51SktSWEZsZlY3
+            UVdpY09yeXpWTi9LOU1XMjJjWkIwN2MK28xZXX5Plc6Oaiqc5zYOUZx4hhQsNB9m
+            ens9cZKwvK+LdghWB8QFs9gGE/JhfAJZVmLf/ZAOqm7KvpXMkDmq7w==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age12khufkd7z25eqgpjjyy0zcrq6kpjxzekmff5zhq7q54tajm4e58qul35x0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMKzc3VURMWFVvRTFzeUwz
+            eU4rc0hqS1dUYjNPVGpSeU0vQjVOajJpMWxzCmZySXh0S2Nla3I1K29VZ2M5ZDV4
+            MW5RaEE3SUZqVmF0dUtqOGNxVHluV0UKLS0tIFI1OG9HUUgwa2syR3pkaGNUellx
+            dk9KdkdKTmJQWDBua2xEZ3dVdjNmM2MKcbqw7V2Pun4twM16EcjkrTycO/D9zXcw
+            gvEmwYQI6ZYac7diRPtiSeH7UKfwLJJ8Rub9ViC+xzbCq7w0s+a+3g==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age16fufeddr0arrns268526gxethxgkh3g0euf8cn37kuwfmq3h23psutz4q8
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuekkvLzBLY2gydTV0OEVX
+            OE16WngrOVpVYURrREVxOUNiTVpWZ1JNemljCnpwS0N6aGVZeG5WZS9ncUIyRWxG
+            Tk5ySW5nWC9VbXpBM3JMMWp1NjRCMUkKLS0tIHRUUndQUHhrTGtXbXNyVG5iV2VQ
+            VUVVS29waWNOTkVseEM3WldLQXc1cmcKc9Kq/sUsBWduApxCybQiiniaiHMsSwEj
+            pftgWYqK03zWTSxe6y7qVhmrEHzuxAw7INTtHcgu9LgddVDnH8JYLw==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1a8e4gxw67kp27s3hssfxyem3e8jwaha3huz0sttfngeu60pk5pxqkfpg3d
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIaFBxQW14VlA4d08rbDJZ
+            bXZlTXRJWjIzRGZ2ODdvMnZyTHFEbzU2WkdjCkFmQ2J3L2pOOUJVTlRYa0s3UERt
+            ekhBaHBORytWVm5vRTB3RmtZbzZONVEKLS0tIG1ORWl4RXdVNW5rOE9FQVpMVGwv
+            dUVwMmhzOHZoUVpzTWh1ZTRnOGNuQkkKv2LEhdNA5eD/pJeHHH5k9aXf9H4YgMke
+            D8Vpu40T1XYhikx6IXbmA3/Wke2Gj0zl3gfLUSytvoYMU3DeADaQtQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1drky6caal0j2x58yzpw9tyflcpdpmcjqy8nss7zfvspszg0xfpdsyzu8s4
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmN0ZHV0QwVjFJUDRoTTlv
+            UTBFVWpYUHU3M3JvcHJpOWUxQXpBbGVVZUV3CkE3SkFNZnRIalFuaElWTkZrQVll
+            a1o5VGVVMXhSZ1dndzczVm9CSW9URmMKLS0tIEtKazV0Wmc2QUNIZjhMR1BTY21s
+            MENLYktZSGdmZFBrTDA3cmMwRGVBRGcK8yWMNC3L5XTbPzsfBPibld89EigO971B
+            VCfGOWOepNdxWOX3+ZASkj0ibckedpibcjymgALRGZiXGNBlR/JIzQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1m57vjw60dpr02ghka8kh2xlqsa0ggxauau2y488zdh89vu760qgqh8lcge
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDYmJRZ0NHelU0bDB6WHRp
+            bUVmeFdXMTdpWG84YU1wUmoyei9FM3lKZ0dFCktxY0RDaTZ3UTB4aFN0WlIwT25P
+            Y3YrMlNUNmwweWxDR2MxSk4rTnhYSDgKLS0tIDVmb3ZhSUc0OTlBSlZ3N3h6WDI2
+            WWphYjNlL3EybkJrQWJ5ZWozby93M1kKLZkfaiWvIJWkev0On+LDQIBDI7H1nLh/
+            aY1eSkwNfHpQPTguqw96d8fF1C/GF5BIMeKG8RRAcGaxHKHMuXj+gA==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1cmq75nz6rxancqlj7g7r2pum8c9xlznuetslmjmthk2g9p4flgdqz0tv8g
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVYW5qRGYrMGZEc3Fpbjhv
+            ZllRbVlmK2krb2w0ZThvc2trU0JRV2h6K0JZCjVFYlprNDRkc20xeVlEeUdIUTRU
+            UzNOOGNsM0ZIb3NyTlU5SGNYSHB1NzgKLS0tIGpDOTd1MWxyWlNkUG5RZFJOaHc4
+            d0F3TUw1VVJqa25YSm53bTJpanQrTU0KuPV5CGjK57edAPBwMIe37Q2YOm4/lABC
+            zOpls19M76vK1uU5z/wv4xtA7Nqp6RTbAyErpCuCJCaULeGH7jEOIw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-06-18T08:11:49Z"
+    mac: ENC[AES256_GCM,data:d6yMv630hcwmR/sz5AbN5bPJjEwdZxERKt1MCZtoUj5UQMsLxuhiB52bVa4fRTNyVRaGejWualuv1rUXusl0bxzQ3AE0vXurDl830p88UOh0LxjUopNLaGapKJZMfPxzIIY3SXyhCDQSpM89T+NLPcMi3wlz+Rdu5JAkmI+Qq3I=,iv:HZjh/kLdjrnklD3ntPMV+vDogwr3W0FmPlwP7PXDs3M=,tag:PwfAhtvAYeNxRa4Qyf4R1w==,type:str]
+    pgp: []
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.9.0

--- a/clusters/staging/management/apps.yaml
+++ b/clusters/staging/management/apps.yaml
@@ -126,6 +126,7 @@ spec:
             # Bring in infra secrets specific to this cluster
             - "secrets://../../../clusters/{{path[1]}}/{{path[2]}}/secrets/infra/api-server-fip.yaml"
             - "secrets://../../../clusters/{{path[1]}}/{{path[2]}}/secrets/infra/app-creds.yaml"
+            - "secrets://../../../clusters/{{path[1]}}/{{path[2]}}/secrets/infra/basic-auth.yaml"
 
       syncPolicy:
         automated:

--- a/clusters/staging/management/infra-values.yaml
+++ b/clusters/staging/management/infra-values.yaml
@@ -19,9 +19,9 @@ stfc-cloud-openstack-cluster:
                   loadBalancerIP: "130.246.215.233"
 
       monitoring:
-        # no need to send alerts around certs/openstack API endpoints for dev/staging clusters 
+        # no need to send alerts around certs/openstack API endpoints for dev/staging clusters
         # ends up with too many messages in the ticket queue
-        blackBoxExporter: 
+        blackBoxExporter:
           enabled: false
         kubePrometheusStack:
           release:
@@ -32,6 +32,10 @@ stfc-cloud-openstack-cluster:
                     cluster: management
                     env: staging
                 ingress:
+                  annotations:
+                    nginx.ingress.kubernetes.io/auth-type: basic
+                    nginx.ingress.kubernetes.io/auth-secret: basic-auth
+                    nginx.ingress.kubernetes.io/auth-realm: "Authentication Required - Staging Management"
                   hosts:
                     - prometheus.staging-mgmt.nubes.stfc.ac.uk
                   tls:
@@ -40,6 +44,10 @@ stfc-cloud-openstack-cluster:
                       secretName: tls-keypair
               grafana:
                 ingress:
+                  annotations:
+                    nginx.ingress.kubernetes.io/auth-type: basic
+                    nginx.ingress.kubernetes.io/auth-secret: basic-auth
+                    nginx.ingress.kubernetes.io/auth-realm: "Authentication Required - Staging Management"
                   hosts:
                     - grafana.staging-mgmt.nubes.stfc.ac.uk
                   tls:
@@ -49,6 +57,10 @@ stfc-cloud-openstack-cluster:
               alertmanager:
                 enabled: true
                 ingress:
+                  annotations:
+                    nginx.ingress.kubernetes.io/auth-type: basic
+                    nginx.ingress.kubernetes.io/auth-secret: basic-auth
+                    nginx.ingress.kubernetes.io/auth-realm: "Authentication Required - Staging Management"
                   hosts:
                     - alertmanager.staging-mgmt.nubes.stfc.ac.uk
                   tls:

--- a/clusters/staging/management/secrets/infra/basic-auth.yaml
+++ b/clusters/staging/management/secrets/infra/basic-auth.yaml
@@ -1,0 +1,41 @@
+stfc-cloud-openstack-cluster:
+    openstack-cluster:
+        addons:
+            monitoring:
+                kubePrometheusStack:
+                    release:
+                        values:
+                            prometheus:
+                                extraSecret:
+                                    name: ENC[AES256_GCM,data:Q/RJwTWMa5zdlQ==,iv:kMVINkIiJFWZ6cK+4guSnTWE9m1QCXPHuJXhQgJfs9c=,tag:voLZYpa87fsGqFHcEcYTPw==,type:str]
+                                    data:
+                                        auth: ENC[AES256_GCM,data:XvCQCGQhB7CcJuwDf+XGuuWDLwC4iZvgiWoUAfbr2eJB8Nfk6wz0hA4WoA==,iv:n9Nx/iBsbjeynZd2MXqCOKig8gaJg2g46DQF68Pn9Xk=,tag:Q+7+QC7Eik9T6rGx2E3oFQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1tgfg98jddwc2crr869aa9phe9ufflnyya4t3mcltqsmcvca0k46q2m04se
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBibzJ0b3d2TWdmTUdYcTBj
+            Y3E2VE9YekR5ZFB5VlRtUkI3eXExcFpDa0Q0CjU5Ni82TW8rQ3BJQ2ZwdytBMWJl
+            cjhpelRNSW5uSXNyV2tZbTJqellpOTgKLS0tIGNSV2llWnlyYTYwd3VjL21CZ2xE
+            cXNOZWJrdzVPOXgzYThIbFkwMkxIdXcKUFpoGqN5VmYAaGBYm8OOir1ok7GBpY+C
+            NxOgGsETj0FAtPOaKNWWeSEv2NnymWq9eETNle2tSmt1jQfVnoQSBQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1hsll27prywydttq7dtnqtdnu2jpr8zhaulx00l7n4pqmxkhr55vspqmj6l
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzeFMwaTRSRFQwcWlYUHN1
+            ZDRJaFNSTEpuRHFYaGhFNHRiSUVscnl6SFdBCjE5VU50RG1RdURaZDZYVGpGTGoy
+            ZDZDVUk0Y3ZUak9tKzVzTUxRSVl1RlEKLS0tIElsZGhUUXBQTXZ0bnNEOS9nVW5n
+            UHgrWWIyKzUyeE85NE9zRS9UaHVGMDAKKSOD1s2mOdJIuXQnuc4EklaIACoBfHPc
+            sGz9T/vE9iOnh+M+/cr3maFK1UVSFtoOrta1gRczdRjjJAXY9u5buw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-06-17T17:53:49Z"
+    mac: ENC[AES256_GCM,data:RVZ35B94bJx8/U48Y1PMSnN+WbaB9TwJUW2mka5s6R2ItcPWUM1dVlLgZOxUEIqtAPAD3PvSaq2P3fRaxfKcpG0uxpvZgWKYxJr/55iFFIp6ZUtqB2OsTcuhF8Y0MBpU2H6L7aCHgWCWz0/XUyNc8Nbo23qK9OzmYeb5hEgCKtA=,iv:hfGo5Bda0j9nap9D3GnPs0CvKdetsVSH2CPK3WdV+Zs=,tag:wWIZI3Uq/5vPKbbeMTKfxA==,type:str]
+    pgp: []
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.9.0

--- a/clusters/staging/worker/infra-values.yaml
+++ b/clusters/staging/worker/infra-values.yaml
@@ -1,5 +1,9 @@
 stfc-cloud-openstack-cluster:
   openstack-cluster:
+    auth:
+      monitoring:
+        enabled: true
+
     cloudCredentialsSecretName: staging-worker-cluster-cloud-credentials
 
     controlPlane:
@@ -54,6 +58,10 @@ stfc-cloud-openstack-cluster:
                     env: staging
                 ingress:
                   ingressClassName: internal-nginx
+                  annotations:
+                    nginx.ingress.kubernetes.io/auth-type: basic
+                    nginx.ingress.kubernetes.io/auth-secret: basic-auth
+                    nginx.ingress.kubernetes.io/auth-realm: "Authentication Required - Staging Worker"
                   hosts:
                     - prometheus.staging-worker.nubes.stfc.ac.uk
                   tls:
@@ -63,6 +71,10 @@ stfc-cloud-openstack-cluster:
               grafana:
                 ingress:
                   ingressClassName: internal-nginx
+                  annotations:
+                    nginx.ingress.kubernetes.io/auth-type: basic
+                    nginx.ingress.kubernetes.io/auth-secret: basic-auth
+                    nginx.ingress.kubernetes.io/auth-realm: "Authentication Required - Staging Worker"
                   hosts:
                     - grafana.staging-worker.nubes.stfc.ac.uk
                   tls:
@@ -73,6 +85,10 @@ stfc-cloud-openstack-cluster:
                 enabled: true
                 ingress:
                   ingressClassName: internal-nginx
+                  annotations:
+                    nginx.ingress.kubernetes.io/auth-type: basic
+                    nginx.ingress.kubernetes.io/auth-secret: basic-auth
+                    nginx.ingress.kubernetes.io/auth-realm: "Authentication Required - Staging Worker"
                   hosts:
                     - alertmanager.staging-worker.nubes.stfc.ac.uk
                   tls:

--- a/clusters/staging/worker/secrets/infra/basic-auth.yaml
+++ b/clusters/staging/worker/secrets/infra/basic-auth.yaml
@@ -1,0 +1,41 @@
+stfc-cloud-openstack-cluster:
+    openstack-cluster:
+        addons:
+            monitoring:
+                kubePrometheusStack:
+                    release:
+                        values:
+                            prometheus:
+                                extraSecret:
+                                    name: ENC[AES256_GCM,data:rbIjxW2qZryPeA==,iv:/4CCEZpVpaqKIZL6zMlu8zIrH21zoyuGrpyaiI01Vkg=,tag:5AZdZQ3iUmZbQ1+sJEwrpQ==,type:str]
+                                    data:
+                                        auth: ENC[AES256_GCM,data:gIkmHzaZAxuRQZhto9kdpuqvtMg8KJvofFXTb8CmPCEtnNmANI29TbhrzA==,iv:dVu5OungIBeGgK57swWUnNznl0xBUbxfbdgAfDvLVRM=,tag:x3eHgFTmBivGq3UIEoGQXw==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1tgfg98jddwc2crr869aa9phe9ufflnyya4t3mcltqsmcvca0k46q2m04se
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCZW16YXpWTlJTSVZrbnpO
+            TGdzZDlLQ3Z0by9TU0JINitSZWp5UHVmeWowCmZwTWJYdnNvaEFaWkIwcXgzR01B
+            UHUzbzMvZkgvMC9BejZWa0NiTW9oeGcKLS0tIFhKQ09KZmJwLzQ2ZW1yMlRXTWUy
+            M1hOMnN2N2VuTmdJcm01TjdtcDZwbzAKRvCYe/0qbSmXc0CumMNfqZY47CbtgEVd
+            dazHAx3LgVYiuY2ToLoQnBE55SeZyF5VmYfnCIqYGQb3QudkFwTWLg==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1hsll27prywydttq7dtnqtdnu2jpr8zhaulx00l7n4pqmxkhr55vspqmj6l
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqblY3M2RaWnYzSmwxTzIr
+            NzJUUGFzcDY5enZEMEtUSkZ0U05HWUhkUHdvCnZ2R2w3TCtYVXpHbzRsOXFuam5Y
+            Y2VlUGxxR2VjQVFLQmZ6WndsT1QxV1UKLS0tIDl0YmJrZmpCR2pYNUpRUmtJQURn
+            RDhjWnZvc1NFRGJ3eEFxWVR6UjBtbUEKRYMv6EgV9q+aC4a1RGlvO7flAWf8idx/
+            vp1K6QR7HgIFQ1YvMhA8XRW8TRTSTV0nw+hLJJw/0Ej3xJ+RTchCbg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-06-17T17:53:39Z"
+    mac: ENC[AES256_GCM,data:Uy/FRrZgAACB9MpfykrORwuRSX8zr3r2a5SBDwWidoHk4i2yyvcsZWa9zs9DLD8iorn+xcULnw+dbi1RAZoFflN7/xOWlc4mqdbn8oKTDJ5Th9A3BuUuhSXr5SwGAwRg7C3crGh3UsC90pM85Qd+gMY3ETVp/KSGItS2yNbvH/Y=,iv:lWUXcxu5FLMPobWUZ/oHkcqEFO/rnZ0bY+47ZvDYxjA=,tag:gItYOcM81gWFt/bz8zHGYg==,type:str]
+    pgp: []
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.9.0


### PR DESCRIPTION
### Description:

<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

Setting up basic auth on the monitoring endpoints (prometheus, alertmanager and grafana) for dev and statging

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- If this is a hotfix for production, which needs to be deployed after merging
- If this requires manual work to deploy the PR, e.g. a parameter change
- If this has associated internal documentation too
-->

---

### Submitter:

Have you:

* [ ] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
