### PR TITLE
Bump rabbit consumer chart everywhere to latest minor

### DIFF
--- a/charts/dev/rabbit-consumer/Chart.yaml
+++ b/charts/dev/rabbit-consumer/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: rabbit-consumer
-version: 2.0.0
+version: 2.0.1
 dependencies:
   - repository: https://stfc.github.io/cloud-helm-charts/
     name: stfc-cloud-rabbit-consumer
-    version: 1.9.0
+    version: 1.9.1

--- a/charts/prod/rabbit-consumer/Chart.yaml
+++ b/charts/prod/rabbit-consumer/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: rabbit-consumer
-version: 2.0.0
+version: 2.0.1
 dependencies:
   - repository: https://stfc.github.io/cloud-helm-charts/
     name: stfc-cloud-rabbit-consumer
-    version: 1.9.0
+    version: 1.9.1

--- a/charts/staging/rabbit-consumer/Chart.yaml
+++ b/charts/staging/rabbit-consumer/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: rabbit-consumer
-version: 2.0.0
+version: 2.0.1
 dependencies:
   - repository: https://stfc.github.io/cloud-helm-charts/
     name: stfc-cloud-rabbit-consumer
-    version: 1.9.0
+    version: 1.9.1


### PR DESCRIPTION


### Description:

This is because the only active copy is prod, so unfortunately to get the latest version we have to promote everywhere at the same time

### Special Notes:

- This is a hotfix for production, which will deploy after merging - pulls in https://github.com/stfc/cloud-docker-images/pull/116

---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
