### PR TITLE
add github action to update helm dependencies

### DIFF
--- a/.github/workflows/check_helm_updates.yaml
+++ b/.github/workflows/check_helm_updates.yaml
@@ -1,0 +1,41 @@
+# adapted from https://github.com/camptocamp/helm-dependency-update-action example
+
+name: Update Chart Dependencies
+
+on:
+  schedule:
+    - cron: '0 13 * * 1-5'  # Every working day at 1pm UTC
+  workflow_dispatch:
+
+env:
+  author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+
+jobs:
+  update-deps:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+      
+      - name: Install yq
+        uses: mikefarah/yq@v4
+
+      - name: Update dependencies for Staging Charts
+        id: updater
+        run: ./update_charts.sh
+
+      - name: Create PR with Chart updates
+        if: steps.updater.outputs.updated_charts != '0'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "Update Helm chart dependencies on Staging"
+          title: "Update Helm chart dependencies"
+          body: |
+            This PR updates dependencies for Helm charts under `charts/staging/*` to the latest available versions.
+            - Automatically generated via GitHub Actions
+          branch: update-staging-staging-versions
+          delete-branch: true

--- a/.github/workflows/pr_copied_files.yaml
+++ b/.github/workflows/pr_copied_files.yaml
@@ -18,19 +18,6 @@ jobs:
             prod:
               - charts/prod/**
 
-      - name: Check staging files
-        if: steps.changed-files.outputs.staging_any_changed == 'true'
-        run: |
-          echo "Changed files in staging:"
-          for file in ${{ steps.changed-files.outputs.staging_all_changed_files }}; do
-            echo "Checking $file..."
-            if ! ${{ github.workspace }}/.github/workflows/pr_check_copies.sh "$file" "staging" "dev"; then
-              echo "❌ $file differs from dev version"
-              exit 1
-            fi
-          done
-          echo "✅ All staging files match dev"
-
       - name: Check prod files
         if: steps.changed-files.outputs.prod_any_changed == 'true'
         run: |

--- a/.github/workflows/update_charts.sh
+++ b/.github/workflows/update_charts.sh
@@ -1,7 +1,10 @@
+#!/bin/bash
+
 set -eo pipefail
 updated_charts=()
 
 helm repo add cloud-charts https://stfc.github.io/cloud-helm-charts/
+helm repo add capi-addon-chart https://azimuth-cloud.github.io/cluster-api-addon-provider
 helm repo add argo-cd https://argoproj.github.io/argo-helm
 helm repo update
 
@@ -16,7 +19,6 @@ for chart in ../../charts/staging/*; do
     modified=false
 
     for dep in $deps; do
-        repo=$(yq e ".dependencies[] | select(.name == \"$dep\") | .repository" "$chart_yaml")
         current_version=$(yq e ".dependencies[] | select(.name == \"$dep\") | .version" "$chart_yaml")
 
         # Find latest version from helm repo

--- a/.github/workflows/update_charts.sh
+++ b/.github/workflows/update_charts.sh
@@ -1,0 +1,35 @@
+set -eo pipefail
+updated_charts=()
+
+helm repo add cloud-charts https://stfc.github.io/cloud-helm-charts/
+helm repo add argo-cd https://argoproj.github.io/argo-helm
+helm repo update
+
+for chart in ../../charts/staging/*; do
+    chart_yaml="$chart/Chart.yaml"
+    [ -f "$chart_yaml" ] || continue
+
+    echo "Checking dependencies for $chart_yaml..."
+
+    deps=$(yq e '.dependencies[]?.name' "$chart_yaml")
+
+    modified=false
+
+    for dep in $deps; do
+        repo=$(yq e ".dependencies[] | select(.name == \"$dep\") | .repository" "$chart_yaml")
+        current_version=$(yq e ".dependencies[] | select(.name == \"$dep\") | .version" "$chart_yaml")
+
+        # Find latest version from helm repo
+        latest_version=$(helm search repo "$dep" -o yaml | yq e '.[0].version' -)
+
+        if [[ "$latest_version" != "$current_version" && -n "$latest_version" ]]; then
+        echo "Updating $dep in $chart: $current_version to $latest_version"
+        yq -i ".dependencies[] |= (select(.name == \"$dep\") .version = \"$latest_version\")" "$chart_yaml"
+        modified=true
+        fi
+    done
+
+    if [ "$modified" = true ]; then
+        updated_charts+=("$chart")
+    fi
+done


### PR DESCRIPTION
staging charts will now be updated periodically to the latest chart advertised on cloud-helm-charts

removed the check for testing if dev matches staging because dev is likely to always be in flux. This github action ensures that our latest released charts will always be running on staging