### PR TITLE
Flavor and count tweaks for staging and prod

### DIFF
--- a/clusters/prod/management/infra-values.yaml
+++ b/clusters/prod/management/infra-values.yaml
@@ -1,4 +1,12 @@
 openstack-cluster:
+  nodeGroups:
+    - name: default-md-0
+      machineCount: 2
+      machineFlavor: dep-l2.tiny
+
+  nodeGroupDefaults:
+    machineFlavor: dep-l2.tiny
+
   addons:
     ingress:
       enabled: true

--- a/clusters/prod/worker/infra-values.yaml
+++ b/clusters/prod/worker/infra-values.yaml
@@ -2,6 +2,11 @@ openstack-cluster:
   nodeGroups:
     - name: default-md-0
       machineCount: 5
+      machineFlavor: dep-l2.tiny
+
+  nodeGroupDefaults:
+    machineFlavor: dep-l2.tiny
+
   addons:
     ingress:
       enabled: true

--- a/clusters/staging/management/infra-values.yaml
+++ b/clusters/staging/management/infra-values.yaml
@@ -5,6 +5,11 @@ stfc-cloud-openstack-cluster:
     controlPlane:
       machineFlavor: dep-l2.tiny
 
+    nodeGroups:
+      - name: default-md-0
+        machineCount: 2
+        machineFlavor: dep-l2.tiny
+
     nodeGroupDefaults:
       machineFlavor: dep-l2.tiny
 


### PR DESCRIPTION
### Description:

See each commit for more details
- Set the machine count for each cluster to sensible values based on current usage
- Switch workers for prod to use dep-l2, the same as staging, as our workloads can handle the additional risk and it keeps more space in the non-dep l3 pool

### Special Notes:
---

### Submitter:

Have you:

* [ ] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

We can come back in and increase/decrease these values later on too.

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
