### PR TITLE
MAINT: Promote argocd from staging to prod

### DIFF
--- a/charts/prod/argocd/Chart.yaml
+++ b/charts/prod/argocd/Chart.yaml
@@ -4,5 +4,5 @@ version: 1.0.1
 dependencies:
   # https://github.com/argoproj/argo-helm/releases
   - name: argo-cd
-    version: 7.8.0
+    version: 8.0.2
     repository: https://argoproj.github.io/argo-helm

--- a/charts/prod/argocd/values.yaml
+++ b/charts/prod/argocd/values.yaml
@@ -28,8 +28,6 @@ argo-cd:
         # This is overriden per-cluster in the cluster's argo-values.yaml
         name: "self-signed"
 
-
-
   # Inject Helm-Secrets into the ArgoCD server
   repoServer:
     env:


### PR DESCRIPTION
### Description:
Promote the changes (which have been running on staging for a while) to prod to also patch the version we're running
---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
