### PR TITLE
BUG: turn off blackbox exporters on non-prod clusters

### DIFF
--- a/clusters/dev/management/infra-values.yaml
+++ b/clusters/dev/management/infra-values.yaml
@@ -14,7 +14,7 @@ stfc-cloud-openstack-cluster:
       monitoring:
         # no need to send alerts around certs/openstack API endpoints for dev/staging clusters
         # ends up with too many messages in the ticket queue
-        blackBoxExporter:
+        blackboxExporter:
           enabled: false
         kubePrometheusStack:
           release:

--- a/clusters/dev/worker/infra-values.yaml
+++ b/clusters/dev/worker/infra-values.yaml
@@ -21,7 +21,7 @@ stfc-cloud-openstack-cluster:
         enabled: true
         # no need to send alerts around certs/openstack API endpoints for dev/staging clusters
         # ends up with too many messages in the ticket queue
-        blackBoxExporter:
+        blackboxExporter:
           enabled: false
         kubePrometheusStack:
           release:

--- a/clusters/prod/worker/infra-values.yaml
+++ b/clusters/prod/worker/infra-values.yaml
@@ -19,6 +19,11 @@ openstack-cluster:
                 loadBalancerIP: "130.246.80.243"
 
     monitoring:
+      # no need to send alerts around certs/openstack API endpoints
+      # ends up with too many messages in the ticket queue
+      # sending blackbox alerts from prod management cluster should be enough 
+      blackboxExporter:
+        enabled: false
       kubePrometheusStack:
         release:
           values:

--- a/clusters/staging/management/infra-values.yaml
+++ b/clusters/staging/management/infra-values.yaml
@@ -26,7 +26,7 @@ stfc-cloud-openstack-cluster:
       monitoring:
         # no need to send alerts around certs/openstack API endpoints for dev/staging clusters
         # ends up with too many messages in the ticket queue
-        blackBoxExporter:
+        blackboxExporter:
           enabled: false
         kubePrometheusStack:
           release:

--- a/clusters/staging/worker/infra-values.yaml
+++ b/clusters/staging/worker/infra-values.yaml
@@ -46,7 +46,7 @@ stfc-cloud-openstack-cluster:
         enabled: true
         # no need to send alerts around certs/openstack API endpoints for dev/staging clusters
         # ends up with too many messages in the ticket queue
-        blackBoxExporter:
+        blackboxExporter:
           enabled: false
         kubePrometheusStack:
           release:


### PR DESCRIPTION
don't need every staging/dev cluster sending info on openstack networking issues - typo when setting enabled: false
