### PR TITLE
bump opensearch storage and lower replicas

### DIFF
--- a/clusters/staging/worker/opensearch-values.yaml
+++ b/clusters/staging/worker/opensearch-values.yaml
@@ -24,8 +24,8 @@ stfc-cloud-opensearch:
       
       nodePools:
         - component: nodes
-          diskSize: "50Gi"
-          replicas: 5
+          diskSize: "500Gi"
+          replicas: 3
           persistence:
             pvc:
               accessModes:


### PR DESCRIPTION
bump the cinder storage for opensearch - we're already reaching the cap after 35 days  
