### PR TITLE
silence blackbox probe alerts globally

### DIFF
--- a/clusters/_shared/monitoring.yaml
+++ b/clusters/_shared/monitoring.yaml
@@ -59,6 +59,10 @@ stfc-cloud-openstack-cluster:
 
               prometheus:
                 enabled: true
+                # no need to send alerts around certs/openstack API endpoints K8s clusters
+                # ends up with too many messages in the ticket queue and we have other monitoring to track this
+                blackboxExporter:
+                  enabled: false
                 prometheusSpec:
                   storageSpec:
                     volumeClaimTemplate:

--- a/clusters/staging/management/infra-values.yaml
+++ b/clusters/staging/management/infra-values.yaml
@@ -24,10 +24,6 @@ stfc-cloud-openstack-cluster:
                   loadBalancerIP: "130.246.215.233"
 
       monitoring:
-        # no need to send alerts around certs/openstack API endpoints for dev/staging clusters
-        # ends up with too many messages in the ticket queue
-        blackboxExporter:
-          enabled: false
         kubePrometheusStack:
           release:
             values:

--- a/clusters/staging/worker/infra-values.yaml
+++ b/clusters/staging/worker/infra-values.yaml
@@ -44,10 +44,6 @@ stfc-cloud-openstack-cluster:
 
       monitoring:
         enabled: true
-        # no need to send alerts around certs/openstack API endpoints for dev/staging clusters
-        # ends up with too many messages in the ticket queue
-        blackboxExporter:
-          enabled: false
         kubePrometheusStack:
           release:
             values:


### PR DESCRIPTION
we've got other alerting which tells us when openstack.stfc.ac.uk and the APIs are having issues.

We don't need tickets from every prod cluster telling us this, and they are not tuned correctly so they keep spamming the ticket queue.

So we should turn it off globally
