### PR TITLE
Match our staging and prod rabbit values

### DIFF
--- a/clusters/prod/worker/rabbit-consumer-values.yaml
+++ b/clusters/prod/worker/rabbit-consumer-values.yaml
@@ -1,5 +1,4 @@
 stfc-cloud-rabbit-consumer:
-  replicaCount: 1
   consumer:
     logLevel: INFO
     aquilon:

--- a/clusters/staging/worker/rabbit-consumer-values.yaml
+++ b/clusters/staging/worker/rabbit-consumer-values.yaml
@@ -1,14 +1,12 @@
-
 stfc-cloud-rabbit-consumer:
   consumer:
     logLevel: INFO
+    aquilon:
+      defaultPrefix: vm-openstack-Dev-
 
     queues:
       - "ral.info"
       - "ral.error"
-
-    aquilon:
-      defaultPrefix: vm-openstack-Dev-
 
     rabbitmq:
       host: dev-service4.nubes.rl.ac.uk

--- a/clusters/staging/worker/rabbit-consumer-values.yaml
+++ b/clusters/staging/worker/rabbit-consumer-values.yaml
@@ -17,4 +17,4 @@ stfc-cloud-rabbit-consumer:
       projectId: c9aee696c4b54f12a645af2c951327dc
 
   kerberosSidecar:
-    principle: "HTTP/service1.nubes.rl.ac.uk"
+    principle: "HTTP/dev-service1.nubes.rl.ac.uk"


### PR DESCRIPTION
### Description:

~The container is not starting, I suspect this is because the replica count isn't set properly, but to start any further troubleshooting match these values to a known working copy~

Adjust the layout to match our prod and staging values to make a diff easier too

---

### Submitter:

Have you:

* [x] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
