### PR TITLE
Change all tags from workflows to pinned SHAs

### DIFF
--- a/.github/workflows/check_helm_updates.yaml
+++ b/.github/workflows/check_helm_updates.yaml
@@ -1,5 +1,7 @@
 # adapted from https://github.com/camptocamp/helm-dependency-update-action example
-
+permissions:
+  contents: read
+  
 name: Update Chart Dependencies on Staging
 
 env:
@@ -16,22 +18,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Setup Github Token"
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         
       - name: Set up Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
         with:
           version: 'latest'
 
       - name: Install yq
-        uses: mikefarah/yq@v4
+        uses: mikefarah/yq@0f4fb8d35ec1a939d78dd6862f494d19ec589f19
         
       - name: Update dependencies for Staging Charts
         id: updater
@@ -50,7 +52,7 @@ jobs:
 
       - name: Create PR with Chart updates
         if: steps.updater.outputs.updated_charts != '0'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0
         with:
           token: ${{ steps.app-token.outputs.token }}
           commit-message: "${{ steps.env-vars.outputs.pr_title }}"

--- a/.github/workflows/pr_copied_files.yaml
+++ b/.github/workflows/pr_copied_files.yaml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  
 name: CI Copied Files Check
 on:
   pull_request:
@@ -7,10 +10,10 @@ jobs:
   check_files:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - id: changed-files
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@v4722103cc46bda19c2b464ffe86db46df6922fd323
         with:
           files_yaml: |
             staging:

--- a/.github/workflows/promote_to_prod.yaml
+++ b/.github/workflows/promote_to_prod.yaml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  
 name: Promote Staging Helm Chart Versions to Prod
 
 on:
@@ -15,14 +18,14 @@ jobs:
 
     steps:
       - name: "Setup Github Token"
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Check for changes
         id: check-changes
@@ -56,7 +59,7 @@ jobs:
 
       - name: Commit and Create Pull Request
         if: steps.check-changes.outputs.changes-detected == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0
         with:
           token: ${{ steps.app-token.outputs.token }}
           commit-message: "${{ steps.env-vars.outputs.pr_title }}"


### PR DESCRIPTION
- Change all of the tags in the repo to pinned SHAs as it is best practice as a defence against supply chain attacks

### Description:

<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

### Special Notes:

<!-- This section and header can be removed if not required.

Examples of special notes that must be included in the PR:
- If this is a hotfix for production, which needs to be deployed after merging
- If this requires manual work to deploy the PR, e.g. a parameter change
- If this has associated internal documentation too
-->

---

### Submitter:

Have you:

* [ ] Labelled this PR, e.g. `bug`, `deployment`, `enhancement` ...etc.

- A `deployment` can be reviewed, and merged, by a single reviewer.
- It can only be used to deploy, change, or remove clusters based on existing patterns for staging.
- Anything involving prod, or production facing services must use the normal 2 person review.
- All other PR types require the usual PR process (e.g. 2 person).

---

### Reviewer

Have you:

* [ ] Verified this PR uses the correct label(s) based on the rules above?
* [ ] Checked if this could affect production (e.g. a global value that's changed without an override)?
* [ ] Tested setting this up, if it's not a deployment, to verify it can be redeployed with any documentation if appropriate?
